### PR TITLE
Consolidation parameter for extraneous variants

### DIFF
--- a/analytics_data_api/utils.py
+++ b/analytics_data_api/utils.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from django.db.models import Q
 from rest_framework.authtoken.models import Token
 
@@ -31,3 +33,53 @@ def set_user_auth_token(user, key):
     Token.objects.create(user=user, key=key)
 
     print "Set API key for user %s to %s" % (user, key)
+
+
+def matching_tuple(answer):
+    """ Return tuple containing values which must match for consolidation. """
+    return (
+        answer.question_text,
+        answer.answer_value_text,
+        answer.answer_value_numeric,
+        answer.problem_display_name,
+        answer.correct,
+    )
+
+
+def consolidate_answers(problem):
+    """ Attempt to consolidate erroneously randomized answers. """
+    answer_sets = defaultdict(list)
+    match_tuple_sets = defaultdict(set)
+
+    for answer in problem:
+        answer.consolidated_variant = False
+
+        answer_sets[answer.value_id].append(answer)
+        match_tuple_sets[answer.value_id].add(matching_tuple(answer))
+
+    # If a part has more than one unique tuple of matching fields, do not consolidate.
+    for _, match_tuple_set in match_tuple_sets.iteritems():
+        if len(match_tuple_set) > 1:
+            return problem
+
+    consolidated_answers = []
+
+    for _, answers in answer_sets.iteritems():
+        consolidated_answer = None
+
+        if len(answers) == 1:
+            consolidated_answers.append(answers[0])
+            continue
+
+        for answer in answers:
+            if not consolidated_answer:
+                consolidated_answer = answer
+
+                consolidated_answer.variant = None
+                consolidated_answer.consolidated_variant = True
+            else:
+                consolidated_answer.count += answer.count
+
+        consolidated_answers.append(consolidated_answer)
+
+    return consolidated_answers

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -76,6 +76,29 @@ class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedFiel
         )
 
 
+class ConsolidatedAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
+    """
+    Serializer for consolidated answer distributions.
+    """
+
+    consolidated_variant = serializers.BooleanField()
+
+    class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
+        fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
+
+    # pylint: disable=super-on-old-class
+    def restore_object(self, attrs, instance=None):
+        """
+        Pops and restores non-model field.
+        """
+
+        consolidated_variant = attrs.pop('consolidated_variant', None)
+        distribution = super(ConsolidatedAnswerDistributionSerializer, self).restore_object(attrs, instance)
+        distribution.consolidated_variant = consolidated_variant
+
+        return distribution
+
+
 class GradeDistributionSerializer(ModelSerializerWithCreatedField):
     """
     Representation of the grade_distribution table without id

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -1,11 +1,18 @@
+"""
+API methods for module level data.
+"""
+
+from itertools import groupby
+
 from rest_framework import generics
 
 from analytics_data_api.v0.models import ProblemResponseAnswerDistribution
-from analytics_data_api.v0.serializers import ProblemResponseAnswerDistributionSerializer
+from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer
 from analytics_data_api.v0.models import GradeDistribution
 from analytics_data_api.v0.serializers import GradeDistributionSerializer
 from analytics_data_api.v0.models import SequentialOpenDistribution
 from analytics_data_api.v0.serializers import SequentialOpenDistributionSerializer
+from analytics_data_api.utils import consolidate_answers
 
 
 class ProblemResponseAnswerDistributionView(generics.ListAPIView):
@@ -38,15 +45,30 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
             * variant: For randomized problems, the random seed used. If problem
               is not randomized, value is null.
             * created: The date the count was computed.
+
+    **Parameters**
+
+        You can request consolidation of response counts for erroneously randomized problems.
+
+        consolidate_variants -- If True, attempt to consolidate responses, otherwise, do not.
+
     """
 
-    serializer_class = ProblemResponseAnswerDistributionSerializer
+    serializer_class = ConsolidatedAnswerDistributionSerializer
     allow_empty = False
 
     def get_queryset(self):
         """Select all the answer distribution response having to do with this usage of the problem."""
         problem_id = self.kwargs.get('problem_id')
-        return ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id)
+
+        queryset = ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id')
+
+        consolidated_rows = []
+
+        for _, part in groupby(queryset, lambda x: x.part_id):
+            consolidated_rows += consolidate_answers(list(part))
+
+        return consolidated_rows
 
 
 class GradeDistributionView(generics.ListAPIView):


### PR DESCRIPTION
This PR adds logic and a boolean parameter to the answer distribution API which can consolidate rows for answers to questions which had randomization erroneously enabled.  This is a fix for the issue described in AN-4111 (<a href="https://openedx.atlassian.net/browse/AN-4111">here</a>) and in the thread <a href="https://github.com/edx/edx-analytics-pipeline/pull/40">here</a>.  There is an associated PR open against the API client to expose the consolidate parameter there <a href="https://github.com/edx/edx-analytics-data-api-client/pull/12">here</a>.  Feedback and comments encouraged!  @jbau @dcadams @sarina @clintonb 