### PR TITLE
Enable stats reporting to datadog.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 python: "2.7"
 install:
     - "pip install coveralls"
-script: 
+script:
     - make validate
     - git fetch origin master:refs/remotes/origin/master # https://github.com/edx/diff-cover#troubleshooting
     - make diff.report
 after_success:
     - coveralls
+    - bash ./scripts/build-stats-to-datadog.sh


### PR DESCRIPTION
@clintonb @dsjen 

Got the bash script but didn't enable it! This will actually turn it on. We've made the adjustments on the Travis side so arguably this will turn on this kind of reporting.