### PR TITLE
Remove a SELECT 1 query

### DIFF
--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -39,19 +39,14 @@ class BaseCourseView(generics.ListAPIView):
 
         return super(BaseCourseView, self).get(request, *args, **kwargs)
 
-    def verify_course_exists_or_404(self, course_id):
-        if self.model.objects.filter(course_id=course_id).exists():
-            return True
-
-        raise Http404
-
     def apply_date_filtering(self, queryset):
         raise NotImplementedError
 
     def get_queryset(self):
-        self.verify_course_exists_or_404(self.course_id)
         queryset = self.model.objects.filter(course_id=self.course_id)
         queryset = self.apply_date_filtering(queryset)
+        if not queryset:
+            raise Http404
         return queryset
 
     def get_csv_filename(self):


### PR DESCRIPTION
This call to "exists()" causes a query like this to be run:

```sql
SELECT (1) AS `a` FROM `course_enrollment_gender_daily` WHERE `course_enrollment_gender_daily`.`course_id` = '<course_id>' LIMIT 1;
```

This query is surprisingly slow (in spite of the limit clause). This patch simply runs the actual queries we want to run and returns a 404 if no data is found.

Reviewer: @clintonb 