### PR TITLE
Improved 404 Handling

### DIFF
--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -144,19 +144,17 @@ class CourseViewTestCaseMixin(DemoCourseMixin):
         raise NotImplementedError
 
     def assertIntervalFilteringWorks(self, expected_response, start_date, end_date):
-        # If start date is after date of existing data, no data should be returned
+        # If start date is after date of existing data, return a 404
         date = (start_date + datetime.timedelta(days=30)).strftime(settings.DATE_FORMAT)
         response = self.authenticated_get(
             '%scourses/%s%s?start_date=%s' % (self.api_root_path, self.course_id, self.path, date))
-        self.assertEquals(response.status_code, 200)
-        self.assertListEqual([], response.data)
+        self.assertEquals(response.status_code, 404)
 
-        # If end date is before date of existing data, no data should be returned
+        # If end date is before date of existing data, return a 404
         date = (start_date - datetime.timedelta(days=30)).strftime(settings.DATE_FORMAT)
         response = self.authenticated_get(
             '%scourses/%s%s?end_date=%s' % (self.api_root_path, self.course_id, self.path, date))
-        self.assertEquals(response.status_code, 200)
-        self.assertListEqual([], response.data)
+        self.assertEquals(response.status_code, 404)
 
         # If data falls in date range, data should be returned
         start_date = start_date.strftime(settings.DATE_FORMAT)

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -19,6 +19,7 @@ class BaseCourseView(generics.ListAPIView):
     end_date = None
     course_id = None
     slug = None
+    allow_empty = False
 
     def get(self, request, *args, **kwargs):
         self.course_id = self.kwargs.get('course_id')
@@ -39,17 +40,10 @@ class BaseCourseView(generics.ListAPIView):
 
         return super(BaseCourseView, self).get(request, *args, **kwargs)
 
-    def verify_course_exists_or_404(self, course_id):
-        if self.model.objects.filter(course_id=course_id).exists():
-            return True
-
-        raise Http404
-
     def apply_date_filtering(self, queryset):
         raise NotImplementedError
 
     def get_queryset(self):
-        self.verify_course_exists_or_404(self.course_id)
         queryset = self.model.objects.filter(course_id=self.course_id)
         queryset = self.apply_date_filtering(queryset)
         return queryset


### PR DESCRIPTION
The query to check if course data exists can be quite slow for some tables. Instead of running this query, we simply execute the actual query to retrieve data. If no data is returned, DRF will return a 404.

@mulby 