### PR TITLE
Added cumulative_count field to enrollment/mode endpoint.

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -91,6 +91,7 @@ class Command(BaseCommand):
         # Create new data
         daily_total = 1500
         date = start_date
+        cumulative_count = 0
 
         while date <= end_date:
             daily_total = get_count(daily_total)
@@ -98,8 +99,9 @@ class Command(BaseCommand):
 
             for mode, ratio in enrollment_mode_ratios.iteritems():
                 count = int(ratio * daily_total)
+                cumulative_count = max(cumulative_count + 10, count)
                 models.CourseEnrollmentModeDaily.objects.create(course_id=course_id, date=date, count=count,
-                                                                mode=mode)
+                                                                cumulative_count=cumulative_count, mode=mode)
 
             for gender, ratio in gender_ratios.iteritems():
                 count = int(ratio * daily_total)

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -46,6 +46,7 @@ class CourseEnrollmentDaily(BaseCourseEnrollment):
 
 class CourseEnrollmentModeDaily(BaseCourseEnrollment):
     mode = models.CharField(max_length=255)
+    cumulative_count = models.IntegerField(null=False)
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_mode_daily'

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -198,6 +198,8 @@ class CourseEnrollmentModeDailySerializer(BaseCourseEnrollmentModelSerializer):
             # Create a transform method for each field
             setattr(self, 'transform_%s' % mode, self._transform_mode)
 
+        fields['cumulative_count'] = serializers.IntegerField(required=True, default=0)
+
         return fields
 
     def _transform_mode(self, _obj, value):
@@ -207,7 +209,7 @@ class CourseEnrollmentModeDailySerializer(BaseCourseEnrollmentModelSerializer):
         model = models.CourseEnrollmentDaily
 
         # Declare the dynamically-created fields here as well so that they will be picked up by Swagger.
-        fields = ['course_id', 'date', 'count', 'created'] + ENROLLMENT_MODES
+        fields = ['course_id', 'date', 'count', 'cumulative_count', 'created'] + ENROLLMENT_MODES
 
 
 class CountrySerializer(serializers.Serializer):

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -426,9 +426,11 @@ class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFi
         arg = args[0]
         response = self.serialize_enrollment(arg)
         total = 0
+        cumulative = 0
 
         for ce in args:
             total += ce.count
+            cumulative += ce.cumulative_count
             response[ce.mode] = ce.count
 
         # Merge the honor and audit modes
@@ -439,6 +441,7 @@ class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFi
         del response[enrollment_modes.PROFESSIONAL_NO_ID]
 
         response[u'count'] = total
+        response[u'cumulative_count'] = cumulative
 
         return [response]
 
@@ -446,7 +449,8 @@ class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFi
         self.destroy_data()
 
         # Create a single entry for a single enrollment mode
-        enrollment = G(self.model, course_id=self.course_id, date=self.date, mode=enrollment_modes.AUDIT, count=1)
+        enrollment = G(self.model, course_id=self.course_id, date=self.date, mode=enrollment_modes.AUDIT,
+                       count=1, cumulative_count=100)
 
         # Create the expected data
         modes = list(enrollment_modes.ALL)
@@ -459,6 +463,7 @@ class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFi
 
         expected.update(self.serialize_enrollment(enrollment))
         expected[u'count'] = 1
+        expected[u'cumulative_count'] = 100
 
         expected = [expected]
         self.assertViewReturnsExpectedData(expected)

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -466,6 +466,7 @@ class CourseEnrollmentModeView(BaseCourseEnrollmentView):
             * course_id: The ID of the course for which data is returned.
             * date: The date for which the enrollment count was computed.
             * count: The total count of enrolled users.
+            * cumulative_count: The cumulative count of users ever enrolled.
             * created: The date the counts were computed.
             * honor: The number of users enrolled in honor code mode.
             * professional: The number of users enrolled in professional mode.
@@ -503,12 +504,14 @@ class CourseEnrollmentModeView(BaseCourseEnrollmentView):
             }
 
             total = 0
+            cumulative_total = 0
 
             for enrollment in group:
                 mode = enrollment.mode
                 item[mode] = enrollment.count
                 item[u'created'] = max(enrollment.created, item[u'created']) if item[u'created'] else enrollment.created
                 total += enrollment.count
+                cumulative_total += enrollment.cumulative_count
 
             # Merge audit and honor
             item[enrollment_modes.HONOR] = item.get(enrollment_modes.HONOR, 0) + item.pop(enrollment_modes.AUDIT, 0)
@@ -518,6 +521,7 @@ class CourseEnrollmentModeView(BaseCourseEnrollmentView):
                 item.get(enrollment_modes.PROFESSIONAL, 0) + item.pop(enrollment_modes.PROFESSIONAL_NO_ID, 0)
 
             item[u'count'] = total
+            item[u'cumulative_count'] = cumulative_total
 
             formatted_data.append(item)
 


### PR DESCRIPTION
This assumes that the `cumulative_count` column is in the `course_enrollment_mode_daily` table.  If the data pipeline is ready to generate this data, I can go ahead and merge this in once reviewed.

@jab5569 @mulby @brianhw 