### PR TITLE
User profiles API

### DIFF
--- a/analytics_data_api/constants/educ_level.py
+++ b/analytics_data_api/constants/educ_level.py
@@ -1,0 +1,16 @@
+UNKNOWN = 'unknown'
+
+LEVEL_OF_EDUCATION_LOOKUP = dict([
+    ('p', 'doctorate'),
+    ('m', 'masters'),  # Master's or professional degree
+    ('b', 'bachelors'),
+    ('a', "associate"),
+    ('hs', "secondary"),
+    ('jhs', "middle"),
+    ('el', "elementary"),
+    ('none', "none"),
+    ('other', "other"),
+    # Deprecated:
+    ('p_se', 'doctorate'),  # Doctorate in science or engineering
+    ('p_oth', 'doctorate'),  # Doctorate in another field
+])

--- a/analytics_data_api/constants/educ_level.py
+++ b/analytics_data_api/constants/educ_level.py
@@ -1,6 +1,6 @@
 UNKNOWN = 'unknown'
 
-LEVEL_OF_EDUCATION_LOOKUP = {
+EDUCATION_LEVELS = {
     'p': 'doctorate',
     'm': 'masters',  # Master's or professional degree
     'b': 'bachelors',

--- a/analytics_data_api/constants/educ_level.py
+++ b/analytics_data_api/constants/educ_level.py
@@ -1,16 +1,16 @@
 UNKNOWN = 'unknown'
 
-LEVEL_OF_EDUCATION_LOOKUP = dict([
-    ('p', 'doctorate'),
-    ('m', 'masters'),  # Master's or professional degree
-    ('b', 'bachelors'),
-    ('a', "associate"),
-    ('hs', "secondary"),
-    ('jhs', "middle"),
-    ('el', "elementary"),
-    ('none', "none"),
-    ('other', "other"),
+LEVEL_OF_EDUCATION_LOOKUP = {
+    'p': 'doctorate',
+    'm': 'masters',  # Master's or professional degree
+    'b': 'bachelors',
+    'a': "associate",
+    'hs': "secondary",
+    'jhs': "middle",
+    'el': "elementary",
+    'none': "none",
+    'other': "other",
     # Deprecated:
-    ('p_se', 'doctorate'),  # Doctorate in science or engineering
-    ('p_oth', 'doctorate'),  # Doctorate in another field
-])
+    'p_se': 'doctorate',  # Doctorate in science or engineering
+    'p_oth': 'doctorate',  # Doctorate in another field
+}

--- a/analytics_data_api/constants/genders.py
+++ b/analytics_data_api/constants/genders.py
@@ -3,3 +3,8 @@ MALE = u'male'
 OTHER = u'other'
 UNKNOWN = u'unknown'
 ALL = [FEMALE, MALE, OTHER, UNKNOWN]
+CLEANED_GENDERS = {
+    u'f': FEMALE,
+    u'm': MALE,
+    u'o': OTHER
+}

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -88,6 +88,17 @@ class CourseEnrollmentByGender(BaseCourseEnrollment):
         unique_together = [('course_id', 'date', 'gender')]
 
 
+class CourseEnrollmentSnapshot(models.Model):
+    """ The most up-to-date enrollment information """
+    course_id = models.CharField(max_length=255, null=False)
+    user = models.ForeignKey('UserProfile', related_name='courses', null=False, db_column='user_id')
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta(object):
+        db_table = 'course_enrollment_snapshot'
+        unique_together = [('course_id', 'user',)]
+
+
 class BaseProblemResponseAnswerDistribution(models.Model):
     """ Base model for the answer_distribution table. """
 

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from analytics_data_api.constants import country, genders
+from analytics_data_api.constants import country, genders, educ_level
 
 
 class CourseActivityWeekly(models.Model):
@@ -73,12 +73,6 @@ class CourseEnrollmentByEducation(BaseCourseEnrollment):
 
 
 class CourseEnrollmentByGender(BaseCourseEnrollment):
-    CLEANED_GENDERS = {
-        u'f': genders.FEMALE,
-        u'm': genders.MALE,
-        u'o': genders.OTHER
-    }
-
     gender = models.CharField(max_length=255, null=True, db_column='gender')
 
     @property
@@ -86,7 +80,7 @@ class CourseEnrollmentByGender(BaseCourseEnrollment):
         """
         Returns the gender with full names and 'unknown' replacing null/None.
         """
-        return self.CLEANED_GENDERS.get(self.gender, genders.UNKNOWN)
+        return genders.CLEANED_GENDERS.get(self.gender, genders.UNKNOWN)
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_gender_daily'
@@ -172,6 +166,36 @@ class SequentialOpenDistribution(models.Model):
     course_id = models.CharField(db_index=True, max_length=255)
     count = models.IntegerField()
     created = models.DateTimeField(auto_now_add=True)
+
+
+class UserProfile(models.Model):
+    """ User Account and Profile information """
+    username = models.CharField(max_length=30, unique=True, db_index=True)
+    last_login = models.DateTimeField()
+    date_joined = models.DateTimeField()
+    is_staff = models.BooleanField(default=False, null=False)
+    email = models.EmailField(blank=True, max_length=75)
+    name = models.CharField(max_length=255)
+    gender_raw = models.CharField(max_length=6, null=True, db_column='gender')
+    year_of_birth = models.IntegerField(null=True)
+    level_of_education_raw = models.CharField(max_length=6, null=True, db_column='level_of_education')
+
+    @property
+    def gender(self):
+        """
+        Returns the gender with full names and 'unknown' replacing null/None.
+        """
+        return genders.CLEANED_GENDERS.get(self.gender_raw, genders.UNKNOWN)
+
+    @property
+    def level_of_education(self):
+        """
+        Returns the user's level of education with 'unknown' replacing null/None.
+        """
+        return educ_level.LEVEL_OF_EDUCATION_LOOKUP.get(self.level_of_education_raw, educ_level.UNKNOWN)
+
+    class Meta(object):
+        db_table = 'user_profile'
 
 
 class BaseVideo(models.Model):

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -203,7 +203,7 @@ class UserProfile(models.Model):
         """
         Returns the user's level of education with 'unknown' replacing null/None.
         """
-        return educ_level.LEVEL_OF_EDUCATION_LOOKUP.get(self.level_of_education_raw, educ_level.UNKNOWN)
+        return educ_level.EDUCATION_LEVELS.get(self.level_of_education_raw, educ_level.UNKNOWN)
 
     class Meta(object):
         db_table = 'user_profile'

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -306,3 +306,23 @@ class VideoTimelineSerializer(ModelSerializerWithCreatedField):
             'num_views',
             'created'
         )
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    gender = serializers.CharField()
+    level_of_education = serializers.CharField()
+
+    class Meta(object):
+        model = models.UserProfile
+        fields = (
+            'id',
+            'username',
+            'last_login',
+            'date_joined',
+            'is_staff',
+            'email',
+            'name',
+            'gender',
+            'year_of_birth',
+            'level_of_education',
+        )

--- a/analytics_data_api/v0/tests/views/test_users.py
+++ b/analytics_data_api/v0/tests/views/test_users.py
@@ -8,9 +8,63 @@ from analyticsdataserver.tests import TestCaseWithAuthentication
 class UsersTests(TestCaseWithAuthentication):
 
     def _get_data(self, user_id=None):
-        return self.authenticated_get('/api/v0/users/{}/profile'.format(user_id))
+        return self.authenticated_get('/api/v0/users/{}/'.format(user_id))
 
-    def test_get(self):
+    def test_get_list(self):
+        date_value = timezone.now()
+        G(
+            models.UserProfile,
+            id=2000,
+            username="bob",
+            last_login=date_value,
+            date_joined=date_value,
+            email="bob@example.com",
+            name="Bob Loblaw",
+            year_of_birth=1789,
+        )
+        G(
+            models.UserProfile,
+            id=2001,
+            username="alexa",
+            last_login=date_value,
+            date_joined=date_value,
+            email="alexa@example.com",
+            name="Alexa Anderson",
+            gender_raw="f",
+            year_of_birth=1987,
+        )
+
+        expected = [
+            {
+                "id": 2000,
+                "username": "bob",
+                "last_login": date_value,
+                "date_joined": date_value,
+                "is_staff": False,
+                "email": "bob@example.com",
+                "name": "Bob Loblaw",
+                "gender": "unknown",
+                "year_of_birth": 1789,
+                "level_of_education": "unknown"
+            },
+            {
+                "id": 2001,
+                "username": "alexa",
+                "last_login": date_value,
+                "date_joined": date_value,
+                "is_staff": False,
+                "email": "alexa@example.com",
+                "name": "Alexa Anderson",
+                "gender": "female",
+                "year_of_birth": 1987,
+                "level_of_education": "unknown"
+            },
+        ]
+        response = self.authenticated_get('/api/v0/users/')
+        self.assertEquals(response.status_code, 200)
+        self.assertListEqual(response.data, expected)
+
+    def test_get_profile(self):
         date_value = timezone.now()
         G(
             models.UserProfile,
@@ -42,6 +96,6 @@ class UsersTests(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    def test_get_404(self):
+    def test_get_profile_404(self):
         response = self._get_data('no_id')
         self.assertEquals(response.status_code, 404)

--- a/analytics_data_api/v0/tests/views/test_users.py
+++ b/analytics_data_api/v0/tests/views/test_users.py
@@ -7,78 +7,20 @@ from analyticsdataserver.tests import TestCaseWithAuthentication
 
 class UsersTests(TestCaseWithAuthentication):
 
-    def _get_data(self, user_id=None):
-        return self.authenticated_get('/api/v0/users/{}/'.format(user_id))
-
-    def test_get_list(self):
-        date_value = timezone.now()
-        G(
-            models.UserProfile,
-            id=2000,
-            username="bob",
-            last_login=date_value,
-            date_joined=date_value,
-            email="bob@example.com",
-            name="Bob Loblaw",
-            year_of_birth=1789,
-        )
-        G(
-            models.UserProfile,
-            id=2001,
-            username="alexa",
-            last_login=date_value,
-            date_joined=date_value,
-            email="alexa@example.com",
-            name="Alexa Anderson",
-            gender_raw="f",
-            year_of_birth=1987,
-        )
-
-        expected = [
-            {
-                "id": 2000,
-                "username": "bob",
-                "last_login": date_value,
-                "date_joined": date_value,
-                "is_staff": False,
-                "email": "bob@example.com",
-                "name": "Bob Loblaw",
-                "gender": "unknown",
-                "year_of_birth": 1789,
-                "level_of_education": "unknown"
-            },
-            {
-                "id": 2001,
-                "username": "alexa",
-                "last_login": date_value,
-                "date_joined": date_value,
-                "is_staff": False,
-                "email": "alexa@example.com",
-                "name": "Alexa Anderson",
-                "gender": "female",
-                "year_of_birth": 1987,
-                "level_of_education": "unknown"
-            },
-        ]
-        response = self.authenticated_get('/api/v0/users/')
-        self.assertEquals(response.status_code, 200)
-        self.assertIsInstance(response.data, dict)
-        self.assertEqual(response.data['count'], 2)
-        self.assertEqual(response.data['previous'], None)
-        self.assertEqual(response.data['next'], None)
-        self.assertListEqual(response.data['results'], expected)
+    def _get_data(self, username=None):
+        return self.authenticated_get('/api/v0/users/{}/'.format(username))
 
     def test_get_profile(self):
         date_value = timezone.now()
         G(
             models.UserProfile,
             id=2000,
-            username="bob",
+            username="fred",
             last_login=date_value,
             date_joined=date_value,
             is_staff=False,
-            email="bob@example.com",
-            name="Bob Loblaw",
+            email="fred@example.com",
+            name="Fred Loblaw",
             gender_raw="m",
             year_of_birth=1789,
             level_of_education_raw="p",
@@ -86,20 +28,20 @@ class UsersTests(TestCaseWithAuthentication):
 
         expected = {
             "id": 2000,
-            "username": "bob",
+            "username": "fred",
             "last_login": date_value,
             "date_joined": date_value,
             "is_staff": False,
-            "email": "bob@example.com",
-            "name": "Bob Loblaw",
+            "email": "fred@example.com",
+            "name": "Fred Loblaw",
             "gender": "male",
             "year_of_birth": 1789,
             "level_of_education": "doctorate"
         }
-        response = self._get_data(2000)
+        response = self._get_data('fred')
         self.assertEquals(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
     def test_get_profile_404(self):
-        response = self._get_data('no_id')
+        response = self._get_data('other')
         self.assertEquals(response.status_code, 404)

--- a/analytics_data_api/v0/tests/views/test_users.py
+++ b/analytics_data_api/v0/tests/views/test_users.py
@@ -62,7 +62,11 @@ class UsersTests(TestCaseWithAuthentication):
         ]
         response = self.authenticated_get('/api/v0/users/')
         self.assertEquals(response.status_code, 200)
-        self.assertListEqual(response.data, expected)
+        self.assertIsInstance(response.data, dict)
+        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['previous'], None)
+        self.assertEqual(response.data['next'], None)
+        self.assertListEqual(response.data['results'], expected)
 
     def test_get_profile(self):
         date_value = timezone.now()

--- a/analytics_data_api/v0/tests/views/test_users.py
+++ b/analytics_data_api/v0/tests/views/test_users.py
@@ -1,0 +1,47 @@
+from django.utils import timezone
+from django_dynamic_fixture import G
+
+from analytics_data_api.v0 import models
+from analyticsdataserver.tests import TestCaseWithAuthentication
+
+
+class UsersTests(TestCaseWithAuthentication):
+
+    def _get_data(self, user_id=None):
+        return self.authenticated_get('/api/v0/users/{}/profile'.format(user_id))
+
+    def test_get(self):
+        date_value = timezone.now()
+        G(
+            models.UserProfile,
+            id=2000,
+            username="bob",
+            last_login=date_value,
+            date_joined=date_value,
+            is_staff=False,
+            email="bob@example.com",
+            name="Bob Loblaw",
+            gender_raw="m",
+            year_of_birth=1789,
+            level_of_education_raw="p",
+        )
+
+        expected = {
+            "id": 2000,
+            "username": "bob",
+            "last_login": date_value,
+            "date_joined": date_value,
+            "is_staff": False,
+            "email": "bob@example.com",
+            "name": "Bob Loblaw",
+            "gender": "male",
+            "year_of_birth": 1789,
+            "level_of_education": "doctorate"
+        }
+        response = self._get_data(2000)
+        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.data, expected)
+
+    def test_get_404(self):
+        response = self._get_data('no_id')
+        self.assertEquals(response.status_code, 404)

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -6,6 +6,7 @@ urlpatterns = patterns(
     '',
     url(r'^courses/', include('analytics_data_api.v0.urls.courses', namespace='courses')),
     url(r'^problems/', include('analytics_data_api.v0.urls.problems', namespace='problems')),
+    url(r'^users/', include('analytics_data_api.v0.urls.users', namespace='users')),
     url(r'^videos/', include('analytics_data_api.v0.urls.videos', namespace='videos')),
 
     # pylint: disable=no-value-for-parameter

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -13,7 +13,8 @@ COURSE_URLS = [
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
-    ('videos', views.VideosListView, 'videos')
+    ('users', views.UserListView, 'users'),
+    ('videos', views.VideosListView, 'videos'),
 ]
 
 urlpatterns = []

--- a/analytics_data_api/v0/urls/users.py
+++ b/analytics_data_api/v0/urls/users.py
@@ -3,8 +3,7 @@ from django.conf.urls import patterns, url
 from analytics_data_api.v0.views import users as views
 
 USER_URLS = [
-    (r'^$', views.UserListView, 'user_list'),
-    (r'^(?P<user_id>.+)/$', views.UserProfileView, 'user_profile'),
+    (r'^(?P<username>[^/]+)/$', views.UserProfileView, 'user_profile'),
 ]
 
 urlpatterns = []

--- a/analytics_data_api/v0/urls/users.py
+++ b/analytics_data_api/v0/urls/users.py
@@ -1,14 +1,13 @@
-import re
-
 from django.conf.urls import patterns, url
 
 from analytics_data_api.v0.views import users as views
 
 USER_URLS = [
-    ('profile', views.UserProfileView, 'user_profile'),
+    (r'^$', views.UserListView, 'user_list'),
+    (r'^(?P<user_id>.+)/$', views.UserProfileView, 'user_profile'),
 ]
 
 urlpatterns = []
 
 for path, view, name in USER_URLS:
-    urlpatterns += patterns('', url(r'^(?P<pk>.+)/' + re.escape(path) + r'/$', view.as_view(), name=name))
+    urlpatterns += patterns('', url(path, view.as_view(), name=name))

--- a/analytics_data_api/v0/urls/users.py
+++ b/analytics_data_api/v0/urls/users.py
@@ -1,0 +1,14 @@
+import re
+
+from django.conf.urls import patterns, url
+
+from analytics_data_api.v0.views import users as views
+
+USER_URLS = [
+    ('profile', views.UserProfileView, 'user_profile'),
+]
+
+urlpatterns = []
+
+for path, view, name in USER_URLS:
+    urlpatterns += patterns('', url(r'^(?P<pk>.+)/' + re.escape(path) + r'/$', view.as_view(), name=name))

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -689,6 +689,48 @@ GROUP BY module_id;
         return rows
 
 
+class UserListView(generics.ListAPIView):
+    """
+    Get the (paginated) list of all users (students and staff) in the given course.
+
+    **Example Request**
+
+        GET /api/v0/courses/{course_id}/users/
+
+    **Additional parameters**
+
+        These query parameters can be specified to control pagination of the results:
+
+            * limit: Specify how many results to return per page (default is 100).
+            * page: Specify which page of results. 1 is the first page.
+
+    **Response Values**
+
+        Returns an object with pagination info and a 'results' entry that is a collection of user
+        objects. Each user object contains:
+
+            * id: The user's ID (integer)
+            * username: The username (string)
+            * last_login: When the user last logged in to the LMS/Studio (datetime)
+            * date_joined: When the user registered (datetime)
+            * is_staff: True if the user is staff (boolean)
+            * email: The user's email address (string)
+            * name: The user's full name (string)
+            * gender: One of "male", "female", "other", or "unknown" (string)
+            * year_of_birth: Year of birth as integer or null
+            * level_of_education: String indicating self-reported education level, or "unknown"
+    """
+
+    serializer_class = serializers.UserProfileSerializer
+    paginate_by = 100  # When django-rest-framework is updated, convert this to LimitOffsetPagination
+    paginate_by_param = 'limit'
+
+    def get_queryset(self):
+        """ Get the (paginated) list of users enrolled in a specific course """
+        course_id = self.kwargs.get('course_id')
+        return models.UserProfile.objects.filter(courses__course_id=course_id)
+
+
 class VideosListView(BaseCourseView):
     """
     Get data for the videos in a course.

--- a/analytics_data_api/v0/views/users.py
+++ b/analytics_data_api/v0/views/users.py
@@ -16,9 +16,17 @@ class UserListView(generics.ListAPIView):
 
         GET /api/v0/users/
 
+    **Additional parameters**
+
+        These query parameters can be specified to control pagination of the results:
+
+            * limit: Specify how many results to return per page (default is 100).
+            * page: Specify which page of results. 1 is the first page.
+
     **Response Values**
 
-        Returns a collection of user objects. Each user object contains:
+        Returns an object with pagination info and a 'results' entry that is a collection of user
+        objects. Each user object contains:
 
             * id: The user's ID (integer)
             * username: The username (string)
@@ -33,6 +41,8 @@ class UserListView(generics.ListAPIView):
     """
 
     serializer_class = UserProfileSerializer
+    paginate_by = 100  # When django-rest-framework is updated, convert this to LimitOffsetPagination
+    paginate_by_param = 'limit'
 
     def get_queryset(self):
         """Select the view count for a specific module"""

--- a/analytics_data_api/v0/views/users.py
+++ b/analytics_data_api/v0/views/users.py
@@ -1,0 +1,33 @@
+"""
+API methods for user data.
+"""
+from django.http import Http404
+from rest_framework import generics
+
+from analytics_data_api.v0.models import UserProfile
+from analytics_data_api.v0.serializers import UserProfileSerializer
+
+
+class UserProfileView(generics.RetrieveAPIView):
+    """
+    Get the profile data of a user.
+
+    **Example Request**
+
+        GET /api/v0/users/{user_id}/profile/
+
+    **Response Values**
+
+        See the serializer
+    """
+
+    serializer_class = UserProfileSerializer
+    allow_empty = False
+
+    def get_queryset(self):
+        """Select the view count for a specific module"""
+        try:
+            user_id = int(self.kwargs.get('pk'))
+        except ValueError:
+            raise Http404
+        return UserProfile.objects.filter(pk=user_id)

--- a/analytics_data_api/v0/views/users.py
+++ b/analytics_data_api/v0/views/users.py
@@ -1,52 +1,10 @@
 """
 API methods for user data.
 """
-from django.http import Http404
 from rest_framework import generics
 
 from analytics_data_api.v0.models import UserProfile
 from analytics_data_api.v0.serializers import UserProfileSerializer
-
-
-class UserListView(generics.ListAPIView):
-    """
-    Get the (paginated) list of all users (students and staff).
-
-    **Example Request**
-
-        GET /api/v0/users/
-
-    **Additional parameters**
-
-        These query parameters can be specified to control pagination of the results:
-
-            * limit: Specify how many results to return per page (default is 100).
-            * page: Specify which page of results. 1 is the first page.
-
-    **Response Values**
-
-        Returns an object with pagination info and a 'results' entry that is a collection of user
-        objects. Each user object contains:
-
-            * id: The user's ID (integer)
-            * username: The username (string)
-            * last_login: When the user last logged in to the LMS/Studio (datetime)
-            * date_joined: When the user registered (datetime)
-            * is_staff: True if the user is staff (boolean)
-            * email: The user's email address (string)
-            * name: The user's full name (string)
-            * gender: One of "male", "female", "other", or "unknown" (string)
-            * year_of_birth: Year of birth as integer or null
-            * level_of_education: String indicating self-reported education level, or "unknown"
-    """
-
-    serializer_class = UserProfileSerializer
-    paginate_by = 100  # When django-rest-framework is updated, convert this to LimitOffsetPagination
-    paginate_by_param = 'limit'
-
-    def get_queryset(self):
-        """Select the view count for a specific module"""
-        return UserProfile.objects.all()
 
 
 class UserProfileView(generics.RetrieveAPIView):
@@ -55,7 +13,7 @@ class UserProfileView(generics.RetrieveAPIView):
 
     **Example Request**
 
-        GET /api/v0/users/{user_id}/
+        GET /api/v0/users/{username}/
 
     **Response Values**
 
@@ -74,12 +32,6 @@ class UserProfileView(generics.RetrieveAPIView):
     """
 
     serializer_class = UserProfileSerializer
-    lookup_url_kwarg = 'user_id'
-
-    def get_queryset(self):
-        """Select the profile of a specific user"""
-        try:
-            user_id = int(self.kwargs.get('user_id'))
-        except ValueError:
-            raise Http404
-        return UserProfile.objects.filter(pk=user_id)
+    model = UserProfile
+    lookup_url_kwarg = 'username'
+    lookup_field = 'username'

--- a/analytics_data_api/v0/views/users.py
+++ b/analytics_data_api/v0/views/users.py
@@ -8,26 +8,68 @@ from analytics_data_api.v0.models import UserProfile
 from analytics_data_api.v0.serializers import UserProfileSerializer
 
 
+class UserListView(generics.ListAPIView):
+    """
+    Get the (paginated) list of all users (students and staff).
+
+    **Example Request**
+
+        GET /api/v0/users/
+
+    **Response Values**
+
+        Returns a collection of user objects. Each user object contains:
+
+            * id: The user's ID (integer)
+            * username: The username (string)
+            * last_login: When the user last logged in to the LMS/Studio (datetime)
+            * date_joined: When the user registered (datetime)
+            * is_staff: True if the user is staff (boolean)
+            * email: The user's email address (string)
+            * name: The user's full name (string)
+            * gender: One of "male", "female", "other", or "unknown" (string)
+            * year_of_birth: Year of birth as integer or null
+            * level_of_education: String indicating self-reported education level, or "unknown"
+    """
+
+    serializer_class = UserProfileSerializer
+
+    def get_queryset(self):
+        """Select the view count for a specific module"""
+        return UserProfile.objects.all()
+
+
 class UserProfileView(generics.RetrieveAPIView):
     """
     Get the profile data of a user.
 
     **Example Request**
 
-        GET /api/v0/users/{user_id}/profile/
+        GET /api/v0/users/{user_id}/
 
     **Response Values**
 
-        See the serializer
+        Returns an object with these properties:
+
+            * id: The user's ID (integer)
+            * username: The username (string)
+            * last_login: When the user last logged in to the LMS/Studio (datetime)
+            * date_joined: When the user registered (datetime)
+            * is_staff: True if the user is staff (boolean)
+            * email: The user's email address (string)
+            * name: The user's full name (string)
+            * gender: One of "male", "female", "other", or "unknown" (string)
+            * year_of_birth: Year of birth as integer or null
+            * level_of_education: String indicating self-reported education level, or "unknown"
     """
 
     serializer_class = UserProfileSerializer
-    allow_empty = False
+    lookup_url_kwarg = 'user_id'
 
     def get_queryset(self):
-        """Select the view count for a specific module"""
+        """Select the profile of a specific user"""
         try:
-            user_id = int(self.kwargs.get('pk'))
+            user_id = int(self.kwargs.get('user_id'))
         except ValueError:
             raise Http404
         return UserProfile.objects.filter(pk=user_id)


### PR DESCRIPTION
**Description**: This adds an API for retrieving user profiles - see https://github.com/edx/edx-analytics-pipeline/pull/141

**Dependencies**: https://github.com/edx/edx-analytics-pipeline/pull/141

**Partner Information**: Third-party open edX instance, not an edX partner.

**Internal Review**: https://github.com/open-craft/edx-analytics-data-api/pull/1

**Test Instructions**: 
1. Test https://github.com/edx/edx-analytics-pipeline/pull/141 and confirm it's working
2. Start the data API server.
3. Go to http://localhost:8100/docs/#!/api/User_List
4. Enter a valid course ID and press "Try it out!" You should see a list of users that are enrolled in the course, plus their profile info.
5. Go to http://localhost:8100/docs/#!/api/User_Profile
4. Enter a valid `username` and press "Try it out"! You should see the info about the user (name, email, etc.)
5. Back in the terminal, press CTRL-C to stop the server. Then type `make validate` to run the new tests.