### PR TITLE
API for user problem data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Ed Zarecor <ed@edx.org>
 Gabe Mulley <gabe@edx.org>
 Jason Bau <jbau@stanford.edu>
 John Jarvis <jarv@edx.org>
+Tim Krones <t.krones@gmx.net>

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -174,6 +174,19 @@ class SequentialOpenDistribution(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
 
+class UserProblemWeeklyData(models.Model):
+    """ User problem history per week """
+    week_ending = models.CharField(max_length=30)
+    course_id = models.CharField(max_length=255)
+    user_id = models.IntegerField()
+    problem_id = models.CharField(max_length=255)
+    num_attempts = models.IntegerField()
+    final_score = models.CharField(max_length=20)
+
+    class Meta(object):
+        db_table = 'user_problem_weekly_data'
+
+
 class BaseVideo(models.Model):
     """ Base video model. """
     pipeline_video_id = models.CharField(db_index=True, max_length=255)

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -176,15 +176,17 @@ class SequentialOpenDistribution(models.Model):
 
 class UserProblemWeeklyData(models.Model):
     """ User problem history per week """
-    week_ending = models.CharField(max_length=30)
+    week_ending = models.DateField()
     course_id = models.CharField(max_length=255)
     user_id = models.IntegerField()
     problem_id = models.CharField(max_length=255)
     num_attempts = models.IntegerField()
-    final_score = models.CharField(max_length=20)
+    most_recent_score = models.IntegerField()
+    max_score = models.IntegerField()
 
     class Meta(object):
         db_table = 'user_problem_weekly_data'
+        ordering = ('week_ending',)
 
 
 class BaseVideo(models.Model):

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -309,5 +309,7 @@ class VideoTimelineSerializer(ModelSerializerWithCreatedField):
 
 
 class UserProblemWeeklyDataSerializer(serializers.ModelSerializer):
+    week_ending = serializers.DateField(format=settings.DATE_FORMAT)
+
     class Meta(object):
         model = models.UserProblemWeeklyData

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -306,3 +306,8 @@ class VideoTimelineSerializer(ModelSerializerWithCreatedField):
             'num_views',
             'created'
         )
+
+
+class UserProblemWeeklyDataSerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = models.UserProblemWeeklyData

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -661,62 +661,68 @@ class CourseUsersProblemDataTests(DemoCourseMixin, TestCaseWithAuthentication):
         G(
             models.UserProblemWeeklyData,
             id=1,
-            week_ending="2015-08-20",
+            week_ending=datetime.date(2015, 8, 20),
             course_id=self.course_id,
             user_id=user_id,
             problem_id="dummy_problem_1",
             num_attempts=11,
-            final_score='0/3',
+            most_recent_score=0,
+            max_score=3,
         )
         G(
             models.UserProblemWeeklyData,
             id=2,
-            week_ending="2015-08-27",
+            week_ending=datetime.date(2015, 8, 27),
             course_id=self.course_id,
             user_id=user_id,
             problem_id="dummy_problem_2",
             num_attempts=22,
-            final_score='1/3',
+            most_recent_score=1,
+            max_score=3,
         )
         G(
             models.UserProblemWeeklyData,
             id=3,
-            week_ending="2015-09-03",
+            week_ending=datetime.date(2015, 9, 3),
             course_id='dummy_course',  # Belongs to another course, so shouldn't show up in results
             user_id=user_id,
             problem_id="dummy_problem_3",
             num_attempts=33,
-            final_score='2/3',
+            most_recent_score=2,
+            max_score=3,
         )
         G(
             models.UserProblemWeeklyData,
             id=4,
-            week_ending="2015-09-10",
+            week_ending=datetime.date(2015, 9, 10),
             course_id=self.course_id,
             user_id=222,  # Submitted by another user, so shouldn't show up in results
             problem_id="dummy_problem_4",
             num_attempts=44,
-            final_score='2/3',
+            most_recent_score=3,
+            max_score=3,
         )
 
         expected = [
             {
                 "id": 1,
-                "week_ending": "2015-08-20",
+                "week_ending": '2015-08-20',
                 "course_id": self.course_id,
                 "user_id": user_id,
                 "problem_id": "dummy_problem_1",
                 "num_attempts": 11,
-                "final_score": '0/3',
+                "most_recent_score": 0,
+                "max_score": 3,
             },
             {
                 "id": 2,
-                "week_ending": "2015-08-27",
+                "week_ending": '2015-08-27',
                 "course_id": self.course_id,
                 "user_id": user_id,
                 "problem_id": "dummy_problem_2",
                 "num_attempts": 22,
-                "final_score": '1/3',
+                "most_recent_score": 1,
+                "max_score": 3,
             },
         ]
         response = self._get_data(user_id)

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -652,6 +652,84 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 404)
 
 
+class CourseUsersProblemDataTests(DemoCourseMixin, TestCaseWithAuthentication):
+    def _get_data(self, user_id=None):
+        return self.authenticated_get('/api/v0/courses/{}/users/{}/problem_data/'.format(self.course_id, user_id))
+
+    def test_get_problem_data(self):
+        user_id = 111
+        G(
+            models.UserProblemWeeklyData,
+            id=1,
+            week_ending="2015-08-20",
+            course_id=self.course_id,
+            user_id=user_id,
+            problem_id="dummy_problem_1",
+            num_attempts=11,
+            final_score='0/3',
+        )
+        G(
+            models.UserProblemWeeklyData,
+            id=2,
+            week_ending="2015-08-27",
+            course_id=self.course_id,
+            user_id=user_id,
+            problem_id="dummy_problem_2",
+            num_attempts=22,
+            final_score='1/3',
+        )
+        G(
+            models.UserProblemWeeklyData,
+            id=3,
+            week_ending="2015-09-03",
+            course_id='dummy_course',  # Belongs to another course, so shouldn't show up in results
+            user_id=user_id,
+            problem_id="dummy_problem_3",
+            num_attempts=33,
+            final_score='2/3',
+        )
+        G(
+            models.UserProblemWeeklyData,
+            id=4,
+            week_ending="2015-09-10",
+            course_id=self.course_id,
+            user_id=222,  # Submitted by another user, so shouldn't show up in results
+            problem_id="dummy_problem_4",
+            num_attempts=44,
+            final_score='2/3',
+        )
+
+        expected = [
+            {
+                "id": 1,
+                "week_ending": "2015-08-20",
+                "course_id": self.course_id,
+                "user_id": user_id,
+                "problem_id": "dummy_problem_1",
+                "num_attempts": 11,
+                "final_score": '0/3',
+            },
+            {
+                "id": 2,
+                "week_ending": "2015-08-27",
+                "course_id": self.course_id,
+                "user_id": user_id,
+                "problem_id": "dummy_problem_2",
+                "num_attempts": 22,
+                "final_score": '1/3',
+            },
+        ]
+        response = self._get_data(user_id)
+        self.assertEquals(response.status_code, 200)
+        self.assertIsInstance(response.data, list)
+        for expected_dict, actual_dict in zip(expected, response.data):
+            self.assertDictEqual(expected_dict, actual_dict)
+
+    def test_get_problem_data_404(self):
+        response = self._get_data('no_id')
+        self.assertEquals(response.status_code, 404)
+
+
 class CourseVideosListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
     def _get_data(self, course_id=None):
         """

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -13,6 +13,7 @@ COURSE_URLS = [
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
+    (r'users/(?P<user_id>\d+)/problem_data', views.UserProblemWeeklyDataView, 'user_problem_weekly_data'),
     ('videos', views.VideosListView, 'videos')
 ]
 

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -14,6 +14,8 @@ from opaque_keys.edx.keys import CourseKey
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.utils import dictfetchall
 from analytics_data_api.v0 import models, serializers
+from analytics_data_api.v0.models import UserProblemWeeklyData
+from analytics_data_api.v0.serializers import UserProblemWeeklyDataSerializer
 
 
 class BaseCourseView(generics.ListAPIView):
@@ -687,6 +689,40 @@ GROUP BY module_id;
                 row['created'] = datetime.datetime.strptime(created, '%Y-%m-%d %H:%M:%S')
 
         return rows
+
+
+class UserProblemWeeklyDataView(generics.ListAPIView):
+    """
+    Get weekly reports about problem history of a user.
+
+    **Example Request**
+
+        GET /api/v0/courses/{course_id}/users/{user_id}/problem_data/
+
+    **Response Values**
+
+        Returns a list of report objects. Each report object contains:
+
+            * id: ID of problem report
+            * week_ending: Last day of week to which problem report belongs (string)
+            * course_id: ID of course targeted by problem report (string)
+            * user_id: ID of user targeted by problem report (int)
+            * problem_id: ID of problem targeted by problem report (string)
+            * num_attempts: Number of times user identified by user_id submitted problem identified by problem_id (int)
+            * final_score: Grade obtained/max grade, e.g.: 5/10 (string)
+    """
+    serializer_class = UserProblemWeeklyDataSerializer
+
+    def get_queryset(self):
+        """
+        Select problem reports for a specific user.
+        """
+        try:
+            course_id = self.kwargs.get('course_id')
+            user_id = int(self.kwargs.get('user_id'))
+        except ValueError:
+            raise Http404
+        return UserProblemWeeklyData.objects.filter(user_id=user_id, course_id=course_id)
 
 
 class VideosListView(BaseCourseView):

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -709,7 +709,8 @@ class UserProblemWeeklyDataView(generics.ListAPIView):
             * user_id: ID of user targeted by problem report (int)
             * problem_id: ID of problem targeted by problem report (string)
             * num_attempts: Number of times user identified by user_id submitted problem identified by problem_id (int)
-            * final_score: Grade obtained/max grade, e.g.: 5/10 (string)
+            * most_recent_score: Most recent score obtained for problem identified by problem_id (int)
+            * max_score: Max possible score for problem identified by problem_id (int)
     """
     serializer_class = UserProblemWeeklyDataSerializer
 


### PR DESCRIPTION
This PR adds an API for retrieving weekly problem data for individual users (see https://github.com/edx/edx-analytics-pipeline/pull/147).

**Dependencies**

https://github.com/edx/edx-analytics-pipeline/pull/147

**Test Instructions**

1. Test https://github.com/edx/edx-analytics-pipeline/pull/147 and confirm it's working
2. Start the data API server.
3. Go to http://localhost:8100/docs/#!/api/User_Problem_Weekly_Data
4. Enter a valid course ID and user ID and press "Try it out!". You should see a list of problem reports for the corresponding course and user.
5. Back in the terminal, press CTRL-C to stop the server. Then type `make validate` to run the new tests.

**Partner Information**

Third-party open edX instance, not an edX partner.
