### PR TITLE
API for retrieving # of passing students vs. time

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -148,8 +148,23 @@ class CourseEnrollmentByCountry(BaseCourseEnrollment):
         unique_together = [('course_id', 'date', 'country_code')]
 
 
+class CourseGradeBreakdown(models.Model):
+    """ The number of students who have a given letter grade for a given course and date """
+
+    class Meta(object):
+        db_table = 'grade_breakdown'
+
+    course_id = models.CharField(db_index=True, max_length=255)
+    date = models.DateField(null=False)
+    letter_grade = models.CharField(max_length=64, null=True)
+    num_students = models.IntegerField(null=False)
+    percent_students = models.FloatField()
+    is_passing = models.BooleanField(null=False)
+    created = models.DateTimeField(auto_now_add=True)
+
+
 class GradeDistribution(models.Model):
-    """ Each row stores the count of a particular grade on a module for a given course. """
+    """ Each row stores the count of a particular score on a module for a given course. """
 
     class Meta(object):
         db_table = 'grade_distribution'
@@ -159,6 +174,20 @@ class GradeDistribution(models.Model):
     grade = models.IntegerField()
     max_grade = models.IntegerField()
     count = models.IntegerField()
+    created = models.DateTimeField(auto_now_add=True)
+
+
+class StudentGrade(models.Model):
+    """ Stores the current grade of each student in a given course """
+
+    class Meta(object):
+        db_table = 'grades'
+
+    course_id = models.CharField(db_index=True, max_length=255)
+    user_id = models.IntegerField(db_index=True)
+    letter_grade = models.CharField(max_length=64, null=True)
+    percent_grade = models.FloatField()
+    is_passing = models.BooleanField(null=False)
     created = models.DateTimeField(auto_now_add=True)
 
 

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -137,6 +137,13 @@ class ConsolidatedFirstLastAnswerDistributionSerializer(ProblemFirstLastResponse
         return distribution
 
 
+class CoursePassingGradeBreakdownSerializer(serializers.Serializer):
+    """ Serialize the aggregate query results that count passing students per day """
+    date = serializers.DateField(format=settings.DATE_FORMAT)
+    num_students = serializers.IntegerField()
+    percent_students = serializers.FloatField()
+
+
 class GradeDistributionSerializer(ModelSerializerWithCreatedField):
     """
     Representation of the grade_distribution table without id

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -12,6 +12,7 @@ COURSE_URLS = [
     ('enrollment/education', views.CourseEnrollmentByEducationView, 'enrollment_by_education'),
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
+    ('pass_fail_distribution', views.CoursePassingGradeBreakdownView, 'pass_fail_distribution'),
     ('problems', views.ProblemsListView, 'problems'),
     ('videos', views.VideosListView, 'videos')
 ]


### PR DESCRIPTION
**Description**: This adds a new API endpoint to the analytics API server for retrieving data from the [Grades Import Pipeline](https://github.com/edx/edx-analytics-pipeline/pull/149). Specifically, the new endpoint gives the number and percentage of students who are passing the given course as a function of time.

**Dependencies**: 
- https://github.com/edx/edx-analytics-pipeline/pull/149 (Grades Import Pipeline)

**Screenshot**:
Here's a screenshot of Swagger, which gives a nice overview of the new API endpoint:
![screen shot 2015-08-22 at 11 41 24 pm](https://cloud.githubusercontent.com/assets/945577/9427251/742de990-4927-11e5-93ff-6ea0473e3123.png)

**Partner information**: not an edX partner - 3rd party-hosted open edX instance

**Reviewers**: TBD
