### PR TITLE
New API endpoint for retrieving typology data

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -174,6 +174,19 @@ class SequentialOpenDistribution(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
 
+class TypologyEntry(models.Model):
+    """ Categorization of students into 'types' per course section """
+    course_id = models.CharField(db_index=True, max_length=255)
+    chapter_id = models.CharField(max_length=255)
+    video_type = models.IntegerField(null=False)
+    problem_type = models.IntegerField(null=False)
+    num_users = models.IntegerField(null=False)  # The number of users who match video_type and problem_type
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta(object):
+        db_table = 'trajectory'
+
+
 class BaseVideo(models.Model):
     """ Base video model. """
     pipeline_video_id = models.CharField(db_index=True, max_length=255)

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -283,6 +283,18 @@ class CourseActivityWeeklySerializer(serializers.ModelSerializer):
         fields = ('interval_start', 'interval_end', 'course_id', 'any', 'attempted_problem', 'played_video', 'created')
 
 
+class TypologySerializer(ModelSerializerWithCreatedField):
+    class Meta(object):
+        model = models.TypologyEntry
+        fields = (
+            'chapter_id',
+            'video_type',
+            'problem_type',
+            'num_users',
+            'created'
+        )
+
+
 class VideoSerializer(ModelSerializerWithCreatedField):
     class Meta(object):
         model = models.Video

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -652,6 +652,75 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 404)
 
 
+class CourseTypologyViewTests(DemoCourseMixin, TestCaseWithAuthentication):
+    def _get_data(self, course_id=None):
+        """
+        Retrieve typology data for a specified course.
+        """
+        course_id = course_id or self.course_id
+        url = '/api/v0/courses/{}/typology/'.format(course_id)
+        return self.authenticated_get(url)
+
+    def test_get(self):
+        NONE, SOME, ALL = 0, 1, 2
+        created = datetime.datetime.utcnow()
+
+        # add a row for a random course, which shouldn't be included in results
+        G(
+            models.TypologyEntry, created=created, course_id="other", chapter_id="c1",
+            video_type=NONE, problem_type=ALL, num_users=5432,
+        )
+
+        def add_mock_data(**kwargs):
+            """ Add a row of typology data for the demo course """
+            G(models.TypologyEntry, course_id=self.course_id, created=created, **kwargs)
+
+        add_mock_data(chapter_id='week1', video_type=NONE, problem_type=SOME, num_users=400)
+        add_mock_data(chapter_id='week1', video_type=SOME, problem_type=ALL, num_users=256)
+
+        add_mock_data(chapter_id='week2', video_type=ALL, problem_type=ALL, num_users=333)
+        add_mock_data(chapter_id='week2', video_type=SOME, problem_type=ALL, num_users=543)
+
+        expected = [
+            {
+                "chapter_id": "week1",
+                "video_type": NONE,
+                "problem_type": SOME,
+                "num_users": 400,
+                "created": created.strftime(settings.DATETIME_FORMAT)
+            },
+            {
+                "chapter_id": "week1",
+                "video_type": SOME,
+                "problem_type": ALL,
+                "num_users": 256,
+                "created": created.strftime(settings.DATETIME_FORMAT)
+            },
+            {
+                "chapter_id": "week2",
+                "video_type": ALL,
+                "problem_type": ALL,
+                "num_users": 333,
+                "created": created.strftime(settings.DATETIME_FORMAT)
+            },
+            {
+                "chapter_id": "week2",
+                "video_type": SOME,
+                "problem_type": ALL,
+                "num_users": 543,
+                "created": created.strftime(settings.DATETIME_FORMAT)
+            },
+        ]
+
+        response = self._get_data(self.course_id)
+        self.assertEquals(response.status_code, 200)
+        self.assertListEqual(response.data, expected)
+
+    def test_get_404(self):
+        response = self._get_data('foo/bar/course')
+        self.assertEquals(response.status_code, 404)
+
+
 class CourseVideosListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
     def _get_data(self, course_id=None):
         """

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -13,6 +13,7 @@ COURSE_URLS = [
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
+    ('typology', views.TypologyListView, 'typology'),
     ('videos', views.VideosListView, 'videos')
 ]
 

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -689,6 +689,35 @@ GROUP BY module_id;
         return rows
 
 
+class TypologyListView(BaseCourseView):
+    """
+    Get typology data for a course.
+
+    **Example request**
+
+        GET /api/v0/courses/{course_id}/typology/
+
+    **Response Values**
+
+        Returns a collection of entries that each describe a "type" of user
+        in one section of the course. Each entry has the following fields:
+
+            * chapter_id: The block ID of the course section (string)
+            * video_type: How thoroughly these users interacted with videos
+              (integer: 0 = watched none, 1 = watched some, 2 = watched all)
+            * problem_type: How thoroughly these users interacted with problems
+              (integer: 0 = watched none, 1 = watched some, 2 = watched all)
+            * num_users: How many users match video_type and problem_type in this section
+            * created: The date this entry's data was last updated.
+    """
+    serializer_class = serializers.TypologySerializer
+    model = models.TypologyEntry
+
+    def apply_date_filtering(self, queryset):
+        # no date filtering for typology -- just return the queryset
+        return queryset
+
+
 class VideosListView(BaseCourseView):
     """
     Get data for the videos in a course.


### PR DESCRIPTION
**Description**
PR 2 of 4 to implement Student Typology / Trajectory.

This is a pretty simple PR that provides an analytics API endpoint to query the data generated by the typology pipeline (https://github.com/edx/edx-analytics-pipeline/pull/142)

New API endpoint is: `/api/v0/courses/:course_id/typology/`

**Test Instructions**
1. Run the typology pipeline, and ensure there is data in the MySQL "trajectory" table.
2. Go to http://localhost:8100/docs/#!/api/Typology_List , enter a course ID known to have typology data, and see the output.

**Dependencies**:
- https://github.com/edx/edx-analytics-pipeline/pull/142

**Partner information**: not an edX partner - 3rd party-hosted open edX instance

**Reviewers**: @itsjeyd and TBD
