### PR TITLE
Added settings for elasticsearch.

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -1,5 +1,6 @@
 """Common settings and globals."""
 
+from os import environ
 from os.path import abspath, basename, dirname, join, normpath
 from sys import stderr
 
@@ -49,6 +50,11 @@ DATABASES = {
     }
 }
 ########## END DATABASE CONFIGURATION
+
+########## ELASTICSEARCH CONFIGURATION
+ELASTICSEARCH_LEARNERS_HOST = environ.get('ELASTICSEARCH_LEARNERS_HOST', None)
+ELASTICSEARCH_LEARNERS_INDEX = environ.get('ELASTICSEARCH_LEARNERS_INDEX', None)
+########## END ELASTICSEARCH CONFIGURATION
 
 
 ########## GENERAL CONFIGURATION


### PR DESCRIPTION
@dan-f -- this isn't one of the more exciting PRs.

I've added configurations for setting up elastic search.  When it comes time to implement, we can do something like:

```
from elasticsearch_dsl import connections, Index, DocType, String

connections.connections.create_connection(hosts=[settings.ELASTIC_SEARCH_LEARNERS_HOST)
roster = Index(settings.ELASTIC_SEARCH_LEARNERS_INDEX)

# this decorator sets up the index and we could move that step into Meta if this is overkill
@roster.doc_type
class RosterEntry(DocType):
     username = String(index='not_analyzed')
     class Meta:
          doc_type = 'roster_entry'  # this was a key part

# execute search
RosterEntry.search().execute()
```