### PR TITLE
Added learner details endpoint.

### DIFF
--- a/analytics_data_api/constants/engagement_entity_types.py
+++ b/analytics_data_api/constants/engagement_entity_types.py
@@ -1,0 +1,4 @@
+FORUM = 'forum'
+PROBLEM = 'problem'
+VIDEO = 'video'
+ALL = [FORUM, PROBLEM, VIDEO]

--- a/analytics_data_api/constants/engagement_events.py
+++ b/analytics_data_api/constants/engagement_events.py
@@ -1,0 +1,17 @@
+from analytics_data_api.constants import engagement_entity_types
+
+CREATED = 'created'
+RESPONDED = 'responded'
+COMMENTED = 'commented'
+
+ATTEMPTED = 'attempted'
+COMPLETED = 'completed'
+
+PLAYED = 'played'
+
+# map entity types to events
+EVENTS = {
+    engagement_entity_types.FORUM: [CREATED, RESPONDED, COMMENTED],
+    engagement_entity_types.PROBLEM: [ATTEMPTED, COMPLETED],
+    engagement_entity_types.VIDEO: [PLAYED],
+}

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -1,7 +1,11 @@
 from django.conf import settings
 from rest_framework import serializers
 
-from analytics_data_api.constants import enrollment_modes, genders
+from analytics_data_api.constants import (
+    engagement_entity_types,
+    engagement_events,
+    enrollment_modes,
+    genders,)
 from analytics_data_api.v0 import models
 
 
@@ -306,3 +310,30 @@ class VideoTimelineSerializer(ModelSerializerWithCreatedField):
             'num_views',
             'created'
         )
+
+
+class LearnerSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    enrollment_mode = serializers.CharField()
+    name = serializers.CharField()
+    email = serializers.CharField()
+    segments = serializers.Field(source='segments')
+    engagement = serializers.SerializerMethodField('get_engagement')
+
+    # TODO: add these back in when the index returns them
+    # enrollment_date = serializers.DateField(format=settings.DATE_FORMAT, allow_empty=True)
+    # last_updated = serializers.DateField(format=settings.DATE_FORMAT)
+    # cohort = serializers.CharField(allow_none=True)
+
+    def get_engagement(self, obj):
+        """
+        Add the engagement totals.
+        """
+        engagement = {}
+        for entity_type in engagement_entity_types.ALL:
+            for event in engagement_events.EVENTS[entity_type]:
+                metric = '{0}_{1}'.format(entity_type, event)
+                print metric
+                engagement[metric] = getattr(obj, metric, 0)
+                print engagement[metric]
+        return engagement

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -1,0 +1,90 @@
+from elasticsearch_dsl.connections import connections
+from mock import patch, Mock
+
+from analyticsdataserver.tests import TestCaseWithAuthentication
+
+
+class LearnerTests(TestCaseWithAuthentication):
+    path_template = '/api/v0/learners/{}/?course_id={}'
+
+    @classmethod
+    def get_fixture(cls):
+        return {
+            "took": 11,
+            "_shards": {
+                "total": 10,
+                "successful": 10,
+                "failed": 0
+            },
+            "hits": {
+                "total": 33701,
+                "max_score": 7.201823,
+                "hits": [{
+                    "_index": "roster_1_1",
+                    "_type": "roster_entry",
+                    "_id": "edX/DemoX/Demo_Course|ed_xavier",
+                    "_score": 7.201823,
+                    "_source": {
+                        "username": "ed_xavier",
+                        "enrollment_mode": "honor",
+                        "problem_attempted": 43,
+                        "problem_completed": 3,
+                        "forum_created": 0,
+                        "course_id": "edX/DemoX/Demo_Course",
+                        "video_played": 6,
+                        "name": "Edward Xavier",
+                        "segments": ["has_potential"],
+                        "email": "ed_xavier@example.com"
+                    }
+                }]
+            }
+        }
+
+    @classmethod
+    def setUpClass(cls):
+        # mock the elastic search client
+        client = Mock()
+        client.search.return_value = cls.get_fixture()
+        connections.add_connection('default', client)
+
+    def test_get_user(self):
+        user_name = 'ed_xavier'
+        course_id = 'edX/DemoX/Demo_Course'
+        response = self.authenticated_get(self.path_template.format(user_name, course_id))
+        self.assertEquals(response.status_code, 200)
+
+        expected = {
+            "username": "ed_xavier",
+            "enrollment_mode": "honor",
+            "name": "Edward Xavier",
+            "email": "ed_xavier@example.com",
+            "segments": ["has_potential"],
+            "engagement": {
+                "forum_commented": 0,
+                "forum_responded": 0,
+                "problem_attempted": 43,
+                "problem_completed": 3,
+                "video_played": 6,
+                "forum_created": 0
+            }
+        }
+        from pprint import pprint
+        pprint(response.data)
+        self.assertDictEqual(expected, response.data)
+
+    @patch('analytics_data_api.v0.models.RosterEntry.get_course_user', Mock(return_value=[]))
+    def test_not_found(self):
+        user_name = 'a_user'
+        course_id = 'edX/DemoX/Demo_Course'
+        response = self.authenticated_get(self.path_template.format(user_name, course_id))
+        self.assertEquals(response.status_code, 404)
+
+    def test_get_400(self):
+        base_path = '/api/v0/learners/{}'
+        path = (base_path).format('ed_xavier')
+        response = self.authenticated_get(path)
+        self.assertEquals(response.status_code, 400)
+
+        path = self.path_template.format('ed_xavier', 'malformed-course-id')
+        response = self.authenticated_get(path)
+        self.assertEquals(response.status_code, 400)

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -7,6 +7,7 @@ urlpatterns = patterns(
     url(r'^courses/', include('analytics_data_api.v0.urls.courses', namespace='courses')),
     url(r'^problems/', include('analytics_data_api.v0.urls.problems', namespace='problems')),
     url(r'^videos/', include('analytics_data_api.v0.urls.videos', namespace='videos')),
+    url(r'^learners/', include('analytics_data_api.v0.urls.learners', namespace='learners')),
 
     # pylint: disable=no-value-for-parameter
     url(r'^authenticated/$', RedirectView.as_view(url=reverse_lazy('authenticated')), name='authenticated'),

--- a/analytics_data_api/v0/urls/learners.py
+++ b/analytics_data_api/v0/urls/learners.py
@@ -1,0 +1,15 @@
+from django.conf.urls import patterns, url
+
+from analytics_data_api.v0.views import learners as views
+
+USERNAME_PATTERN = r'(?P<username>.+)'
+LEARNERS_URLS = [
+    ('', views.LearnerView, 'learner')
+]
+
+urlpatterns = []
+urlpatterns += patterns('', url(r'^$', views.LearnersListView.as_view(), name='learners'))
+
+for path, view, name in LEARNERS_URLS:
+    regex = r'^{0}/$'.format(USERNAME_PATTERN)
+    urlpatterns += patterns('', url(regex, view.as_view(), name=name))

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -1,0 +1,113 @@
+"""
+API methods for module level data.
+"""
+from django.http import Http404
+import re
+from rest_framework.exceptions import ParseError
+from rest_framework import generics
+
+from analytics_data_api.v0.models import RosterEntry
+from analytics_data_api.v0.serializers import LearnerSerializer
+
+
+class CourseViewMixin(object):
+    """
+    Captures the course_id query arg and validates it.
+    """
+
+    COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+[/+][^/+]+[/+][^/]+)'
+    course_id = None
+
+    def get(self, request, *args, **kwargs):
+        self.course_id = request.QUERY_PARAMS.get('course_id', None)
+        if not self.course_id:
+            raise ParseError('Course ID was not specified')
+        if not re.search(self.COURSE_ID_PATTERN, self.course_id):
+            raise ParseError('Course ID malformed')
+        return super(CourseViewMixin, self).get(request, *args, **kwargs)
+
+
+class LearnersListView(CourseViewMixin, generics.ListAPIView):
+    """
+    TBD
+
+    **Example Request**
+
+        GET TBD
+
+    **Response Values**
+
+        TBD
+
+            * TBD
+
+    **Parameters**
+
+        TBD
+
+    """
+
+    serializer_class = LearnerSerializer
+    allow_empty = False
+
+    def get_queryset(self):
+        roster = RosterEntry.search().filter('term', course_id=self.course_id).execute()
+        return roster
+
+
+class LearnerView(CourseViewMixin, generics.RetrieveAPIView):
+    """
+    Get a particular student's data for a particular course.
+
+    **Example Request**
+
+        GET /api/v0/learners/{username}/?course_id={course_id}
+
+    **Response Values**
+
+        Returns viewing data for each segment of a video.  For each segment,
+        the collection contains the following data.
+
+            * segment: The order of the segment in the video timeline.
+            * num_users: The number of unique users who viewed this segment.
+            * num_views: The number of views for this segment.
+            * created: The date the segment data was computed.
+
+        Returns the user metadata and engagement data:
+
+            * username: User name
+            * enrollment_mode: Enrollment mode, e.g. "honor"
+            * name: User name
+            * email: User email
+            * segments: Classification for this course based on engagement, (e.g. "has_potential")
+            * engagement: Summary of engagement events for a time span
+                * video_played: Number of times a video was played
+                * problem_completed: Number of problems completed
+                * problem_attempted: Number of problems attempted
+                * forum_commented: Number of forums posts commented
+                * forum_responded: Number of forum posts responded
+                * forum_created: Number of forum posts created
+
+    **Parameters**
+
+        You can specify course ID for which you want data.
+
+        course_id -- The course within which user data is requested.
+
+    """
+    serializer_class = LearnerSerializer
+    username = None
+    lookup_field = 'username'
+
+    def get(self, request, *args, **kwargs):
+        self.username = self.kwargs.get('username')
+        return super(LearnerView, self).get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        return RosterEntry.get_course_user(self.course_id, self.username)
+
+    def get_object(self, queryset=None):
+        queryset = self.get_queryset()
+        if len(queryset) == 1:
+            return queryset[0]
+        raise Http404("Object does not exist")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,5 @@ ipython==2.4.1						# BSD
 django-rest-swagger==0.2.8  		# BSD
 djangorestframework-csv==1.3.3		# BSD
 django-countries==3.2               # MIT
+elasticsearch-dsl==0.0.9           # Apache 2.0
 -e git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys


### PR DESCRIPTION
@mulby, @dan-f -- I've added the learner details endpoint.  This PR incorporates elastic search and a stub for the learners list endpoint too.

There are a few entity and event fields that are a bit inconsistent between various specs and the real data, but they should be easy to update when we get aligned on the names.

Also, the path has updated here instead of `/api/learner_analytics/v0/learners`, it is now `/api/v0/learners` for both consistency and potential changes to the API recommendation.