### PR TITLE
Run unit tests against real elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ script:
     - make validate
     - git fetch origin master:refs/remotes/origin/master # https://github.com/edx/diff-cover#troubleshooting
     - make diff.report
-branches:
-    only:
-      - master
 after_success:
     - coveralls
     - bash ./scripts/build-stats-to-datadog.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,15 @@ language: python
 python: "2.7"
 install:
     - "pip install coveralls"
+    - "make test.install_elasticsearch"
 cache: pip
 # Use docker for builds
 sudo: false
+before_script:
+    - make test.run_elasticsearch
+    # Recommended by Travis in order to make sure ElasticSearch
+    # actually starts up.  See # https://docs.travis-ci.com/user/database-setup/#ElasticSearch
+    - sleep 10
 script:
     - make validate
     - git fetch origin master:refs/remotes/origin/master # https://github.com/edx/diff-cover#troubleshooting

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,19 @@ ROOT = $(shell echo "$$PWD")
 COVERAGE = $(ROOT)/build/coverage
 PACKAGES = analyticsdataserver analytics_data_api
 DATABASES = default analytics
+ELASTICSEARCH_VERSION = 1.5.2
 
 .PHONY: requirements develop clean diff.report view.diff.report quality
 
 requirements:
 	pip install -q -r requirements/base.txt
+
+test.install_elasticsearch:
+	curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$(ELASTICSEARCH_VERSION).zip
+	unzip elasticsearch-$(ELASTICSEARCH_VERSION).zip
+
+test.run_elasticsearch:
+	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d
 
 test.requirements: requirements
 	pip install -q -r requirements/test.txt

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,23 @@ Getting Started
        $ ./manage.py migrate --noinput
        $ ./manage.py migrate --noinput --database=analytics
 
+   The learner API endpoints require elasticsearch with a mapping
+   defined on this `wiki page <https://openedx.atlassian.net/wiki/display/AN/Learner+Analytics#LearnerAnalytics-ElasticSearch>`_.
+   The connection to elasticsearch can be configured by the
+   ``ELASTICSEARCH_LEARNERS_HOST`` and
+   ``ELASTICSEARCH_LEARNERS_INDEX`` django settings.  For testing, you
+   can install elasticsearch locally:
+
+   ::
+
+      $ make test.install_elasticsearch
+
+   To run the cluster for testing:
+
+   ::
+
+      $ make test.run_elasticsearch
+
 3. Create a user and authentication token. Note that the user will be
    created if one does not exist.
 

--- a/analytics_data_api/constants/engagement_entity_types.py
+++ b/analytics_data_api/constants/engagement_entity_types.py
@@ -1,5 +1,4 @@
 DISCUSSIONS = 'discussions'
-PROBLEM = 'problem'
 PROBLEMS = 'problems'
 VIDEO = 'videos'
-ALL = [DISCUSSIONS, PROBLEM, PROBLEMS, VIDEO]
+ALL = [DISCUSSIONS, PROBLEMS, VIDEO]

--- a/analytics_data_api/constants/engagement_events.py
+++ b/analytics_data_api/constants/engagement_events.py
@@ -1,6 +1,5 @@
 from analytics_data_api.constants import engagement_entity_types
 
-ATTEMPTS = 'attempts'
 ATTEMPTED = 'attempted'
 COMPLETED = 'completed'
 CONTRIBUTED = 'contributed'
@@ -9,7 +8,6 @@ VIEWED = 'viewed'
 # map entity types to events
 EVENTS = {
     engagement_entity_types.DISCUSSIONS: [CONTRIBUTED],
-    engagement_entity_types.PROBLEM: [ATTEMPTS],
     engagement_entity_types.PROBLEMS: [ATTEMPTED, COMPLETED],
     engagement_entity_types.VIDEO: [VIEWED],
 }

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -21,3 +21,7 @@ INSTALLED_APPS += (
 LMS_USER_ACCOUNT_BASE_URL = 'http://lms-host'
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+# Default elasticsearch port when running locally
+ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9200/'
+ELASTICSEARCH_LEARNERS_INDEX = 'roster_test'


### PR DESCRIPTION
Also removes the 'problem_attempts' field from the roster entry, since
there's no defined use case.

AN-6151