### PR TITLE
New API method to return tags distribution info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Ed Zarecor <ed@edx.org>
 Gabe Mulley <gabe@edx.org>
 Jason Bau <jbau@stanford.edu>
 John Jarvis <jarv@edx.org>
+Dmitry Viskov <dmitry.viskov@webenterprise.ru>

--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -225,6 +225,34 @@ class Command(BaseCommand):
                     course_id=course_id, start_date=start_date, end_date=end_date, metric=metric,
                     range_type='high', low_value=high_floor, high_value=max_value)
 
+    def generate_tags_distribution_data(self, course_id):
+        logger.info("Deleting existed tags distribution data...")
+        models.ProblemsAndTags.objects.all().delete()
+
+        module_id_tpl = 'i4x://test/problem/%d'
+        difficulty_tag = ['Easy', 'Medium', 'Hard']
+        learning_outcome_tag = ['Learned nothing', 'Learned a few things', 'Learned everything']
+        problems_num = 50
+        chance_difficulty = 5
+
+        logger.info("Generating new tags distribution data...")
+        for i in xrange(problems_num):
+            module_id = module_id_tpl % i
+            total_submissions = random.randint(0, 100)
+            correct_submissions = random.randint(0, total_submissions)
+
+            models.ProblemsAndTags.objects.create(
+                course_id=course_id, module_id=module_id,
+                tag_name='learning_outcome', tag_value=random.choice(learning_outcome_tag),
+                total_submissions=total_submissions, correct_submissions=correct_submissions
+            )
+            if random.randint(0, chance_difficulty) != chance_difficulty:
+                models.ProblemsAndTags.objects.create(
+                    course_id=course_id, module_id=module_id,
+                    tag_name='difficulty', tag_value=random.choice(difficulty_tag),
+                    total_submissions=total_submissions, correct_submissions=correct_submissions
+                )
+
     def handle(self, *args, **options):
         course_id = options['course_id']
         username = options['username']
@@ -245,3 +273,4 @@ class Command(BaseCommand):
         self.generate_video_timeline_data(video_id)
         self.generate_learner_engagement_data(course_id, username, start_date, end_date)
         self.generate_learner_engagement_range_data(course_id, start_date, end_date)
+        self.generate_tags_distribution_data(course_id)

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -131,6 +131,21 @@ class ProblemResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
     count = models.IntegerField()
 
 
+class ProblemsAndTags(models.Model):
+    """ Model for the tags_distribution table """
+
+    class Meta(object):
+        db_table = 'tags_distribution'
+
+    course_id = models.CharField(db_index=True, max_length=255)
+    module_id = models.CharField(db_index=True, max_length=255)
+    tag_name = models.CharField(max_length=255)
+    tag_value = models.CharField(max_length=255)
+    total_submissions = models.IntegerField(default=0)
+    correct_submissions = models.IntegerField(default=0)
+    created = models.DateTimeField(auto_now_add=True)
+
+
 class ProblemFirstLastResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
     """ Updated model for answer_distribution table with counts of first and last attempts at problems. """
 

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -57,6 +57,18 @@ class ProblemSerializer(serializers.Serializer):
     created = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
 
 
+class ProblemsAndTagsSerializer(serializers.Serializer):
+    """
+    Serializer for problems and tags.
+    """
+
+    module_id = serializers.CharField(required=True)
+    total_submissions = serializers.IntegerField(default=0)
+    correct_submissions = serializers.IntegerField(default=0)
+    tags = serializers.CharField()
+    created = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
+
+
 class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedField):
     """
     Representation of the Answer Distribution table, without id.

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -650,6 +650,82 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 404)
 
 
+class CourseProblemsAndTagsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
+    def _get_data(self, course_id=None):
+        """
+        Retrieve data for the specified course.
+        """
+
+        course_id = course_id or self.course_id
+        url = '/api/v0/courses/{}/problems_and_tags/'.format(course_id)
+        return self.authenticated_get(url)
+
+    def test_get(self):
+        """
+        The view should return data when data exists for the course.
+        """
+
+        # This data should never be returned by the tests below because the course_id doesn't match.
+        G(models.ProblemsAndTags)
+
+        # Create multiple objects here to test the grouping. Add a model with a different module_id to break up the
+        # natural order and ensure the view properly sorts the objects before grouping.
+        module_id = 'i4x://test/problem/1'
+        alt_module_id = 'i4x://test/problem/2'
+
+        tags = {
+            'difficulty': ['Easy', 'Medium', 'Hard'],
+            'learning_outcome': ['Learned nothing', 'Learned a few things', 'Learned everything']
+        }
+
+        created = datetime.datetime.utcnow()
+        alt_created = created + datetime.timedelta(seconds=2)
+
+        G(models.ProblemsAndTags, course_id=self.course_id, module_id=module_id,
+          tag_name='difficulty', tag_value=tags['difficulty'][0],
+          total_submissions=11, correct_submissions=4, created=created)
+        G(models.ProblemsAndTags, course_id=self.course_id, module_id=module_id,
+          tag_name='learning_outcome', tag_value=tags['learning_outcome'][1],
+          total_submissions=11, correct_submissions=4, created=alt_created)
+        G(models.ProblemsAndTags, course_id=self.course_id, module_id=alt_module_id,
+          tag_name='learning_outcome', tag_value=tags['learning_outcome'][2],
+          total_submissions=4, correct_submissions=0, created=created)
+
+        expected = [
+            {
+                'module_id': module_id,
+                'total_submissions': 11,
+                'correct_submissions': 4,
+                'tags': {
+                    'difficulty': 'Easy',
+                    'learning_outcome': 'Learned a few things',
+                },
+                'created': alt_created.strftime(settings.DATETIME_FORMAT)
+            },
+            {
+                'module_id': alt_module_id,
+                'total_submissions': 4,
+                'correct_submissions': 0,
+                'tags': {
+                    'learning_outcome': 'Learned everything',
+                },
+                'created': created.strftime(settings.DATETIME_FORMAT)
+            }
+        ]
+
+        response = self._get_data(self.course_id)
+        self.assertEquals(response.status_code, 200)
+        self.assertListEqual(sorted(response.data), sorted(expected))
+
+    def test_get_404(self):
+        """
+        The view should return 404 if no data exists for the course.
+        """
+
+        response = self._get_data('foo/bar/course')
+        self.assertEquals(response.status_code, 404)
+
+
 class CourseVideosListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
     def _get_data(self, course_id=None):
         """

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -13,6 +13,7 @@ COURSE_URLS = [
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
+    ('problems_and_tags', views.ProblemsAndTagsListView, 'problems_and_tags'),
     ('videos', views.VideosListView, 'videos')
 ]
 


### PR DESCRIPTION
This PR is related to https://github.com/edx/edx-analytics-pipeline/pull/247 this one.

New API method:
```
curl "http://127.0.0.1:8100/api/v0/courses/foo-bar/problems_and_tags/" \
--header "Authorization: Token changeme" \
--header "Accept: application/json" -v
```
The structure of JSON answer:
```
[
    {
        "module_id": "foo-bar@problem+block@4c218e31d2014ba4a33f5cbc65c185b9",
        "total_submissions": 2,
        "correct_submissions": 1,
        "tags":
        {
            "difficulty": "Hard",
            "learning_outcome": "Learned nothing"
        }
    },
    {
        "module_id": "foo-bar@problem+block@68cf3df029324fa4a3736dee55357ec7",
        "total_submissions": 2,
        "correct_submissions": 0,
        "tags":
        {
            "difficulty": "Hard",
            "learning_outcome": "Learned a few things"
        }
    },
    ...
]
```

@mulby could you please take a look.