### PR TITLE
Upgrade django debug toolbar

### DIFF
--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -54,27 +54,6 @@ CACHES = {
 ########## END CACHE CONFIGURATION
 
 
-########## TOOLBAR CONFIGURATION
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-INSTALLED_APPS += (
-    'debug_toolbar',
-    'django_nose',
-)
-
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-INTERNAL_IPS = ('127.0.0.1',)
-
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-MIDDLEWARE_CLASSES += (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
-
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-DEBUG_TOOLBAR_CONFIG = {
-    'SHOW_TEMPLATE_CONTEXT': True,
-}
-########## END TOOLBAR CONFIGURATION
-
 ########## ANALYTICS DATA API CONFIGURATION
 
 ANALYTICS_DATABASE = 'analytics'

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,3 +1,2 @@
 # Local development dependencies go here
 -r base.txt
-django-debug-toolbar==1.2.2


### PR DESCRIPTION
We don't use django debug toolbar, and it's causing issues in the Insights acceptance test suite.

@dsjen please review.