### PR TITLE
Add DISTINCT to distinct_entity_count query

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -413,7 +413,7 @@ class ModuleEngagementTimelineManager(models.Manager):
         queryset = ModuleEngagement.objects.all().filter(course_id=course_id, username=username) \
             .values('date', 'entity_type', 'event') \
             .annotate(total_count=Sum('count')) \
-            .annotate(distinct_entity_count=Count('entity_id')) \
+            .annotate(distinct_entity_count=Count('entity_id', distinct=True)) \
             .order_by('date')
 
         timelines = []

--- a/analytics_data_api/v0/tests/views/test_engagement_timelines.py
+++ b/analytics_data_api/v0/tests/views/test_engagement_timelines.py
@@ -61,7 +61,7 @@ class EngagementTimelineTests(DemoCourseMixin, VerifyCourseIdMixin, TestCaseWith
             ]
         }
         if expect_id_aggregation:
-            expected_data['days'][0][metric_display_name] = 2
+            expected_data['days'][0][metric_display_name] = 1
         else:
             expected_data['days'][0][metric_display_name] = 10
         path = self.path_template.format(self.DEFAULT_USERNAME, urlquote(self.course_id))


### PR DESCRIPTION
This fixes half the issue of incorrect doubled counts on some engagement metrics. We should only count distinct entries (not duplicates) in the module_engagement table for the distinct_entity_count (the other half is the total_count sum, which is still double counts duplicates).

The pipeline is going to get a fix to remove duplicates that will make the `distinct=True` unnecessary, but since this is both easy and semantic it doesn't hurt to be defensive.