### PR TITLE
Run test ES server on different port to avoid conflict with edx-platform devstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test.install_elasticsearch:
 	echo "http.port: $(ELASTICSEARCH_PORT)" >> elasticsearch-$(ELASTICSEARCH_VERSION)/config/elasticsearch.yml
 
 test.run_elasticsearch:
-	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d
+	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d --http.port=$(ELASTICSEARCH_PORT)
 
 test.requirements: requirements
 	pip install -q -r requirements/test.txt

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ requirements:
 test.install_elasticsearch:
 	curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$(ELASTICSEARCH_VERSION).zip
 	unzip elasticsearch-$(ELASTICSEARCH_VERSION).zip
+	echo "http.port: 9201" >> elasticsearch-$(ELASTICSEARCH_VERSION)/config/elasticsearch.yml
 
 test.run_elasticsearch:
 	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COVERAGE_DIR = $(ROOT)/build/coverage
 PACKAGES = analyticsdataserver analytics_data_api
 DATABASES = default analytics
 ELASTICSEARCH_VERSION = 1.5.2
+ELASTICSEARCH_PORT = 9223
 TEST_SETTINGS = analyticsdataserver.settings.test
 
 .PHONY: requirements develop clean diff.report view.diff.report quality
@@ -13,7 +14,7 @@ requirements:
 test.install_elasticsearch:
 	curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$(ELASTICSEARCH_VERSION).zip
 	unzip elasticsearch-$(ELASTICSEARCH_VERSION).zip
-	echo "http.port: 9201" >> elasticsearch-$(ELASTICSEARCH_VERSION)/config/elasticsearch.yml
+	echo "http.port: $(ELASTICSEARCH_PORT)" >> elasticsearch-$(ELASTICSEARCH_VERSION)/config/elasticsearch.yml
 
 test.run_elasticsearch:
 	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -26,6 +26,6 @@ LMS_USER_ACCOUNT_BASE_URL = 'http://lms-host'
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # Default elasticsearch port when running locally
-ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9201/'
+ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9223/'
 ELASTICSEARCH_LEARNERS_INDEX = 'roster_test'
 ELASTICSEARCH_LEARNERS_UPDATE_INDEX = 'index_update_test'

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -26,6 +26,6 @@ LMS_USER_ACCOUNT_BASE_URL = 'http://lms-host'
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # Default elasticsearch port when running locally
-ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9200/'
+ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9201/'
 ELASTICSEARCH_LEARNERS_INDEX = 'roster_test'
 ELASTICSEARCH_LEARNERS_UPDATE_INDEX = 'index_update_test'


### PR DESCRIPTION
I noticed that the edx-platform devstack was conflicting with the tests in this repo.

1. Start the devstack vagrant VM. The devstack uses version 0.90.13 of elasticsearch and binds to the default port of 9200 on the host machine.
2. Run `make test.run_elasticsearch` in this repo. Because port 9200 is taken, it will choose the next available port: 9201.
3. Run `make validate`. Because the settings/test.py specify that the elasticsearch server is on port 9200, it actually uses the elasticsearch server in the devstack. 0.90.13 doesn't support aggregation functions and most of the tests fail because of this.

My solution is to choose the rather arbitrary port 9223 to always run the test elasticsearch server on. If something is using that port, then the elasticsearch server will fail to start now.

@dsjen @ajpal 