### PR TITLE
Allows time component in start and end date parameters

### DIFF
--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -130,20 +130,20 @@ class CourseViewTestCaseMixin(DemoCourseMixin):
 
     def assertIntervalFilteringWorks(self, expected_response, start_date, end_date):
         # If start date is after date of existing data, return a 404
-        date = (start_date + datetime.timedelta(days=30)).strftime(settings.DATE_FORMAT)
+        date = (start_date + datetime.timedelta(days=30)).strftime(settings.DATETIME_FORMAT)
         response = self.authenticated_get(
             '%scourses/%s%s?start_date=%s' % (self.api_root_path, self.course_id, self.path, date))
         self.assertEquals(response.status_code, 404)
 
         # If end date is before date of existing data, return a 404
-        date = (start_date - datetime.timedelta(days=30)).strftime(settings.DATE_FORMAT)
+        date = (start_date - datetime.timedelta(days=30)).strftime(settings.DATETIME_FORMAT)
         response = self.authenticated_get(
             '%scourses/%s%s?end_date=%s' % (self.api_root_path, self.course_id, self.path, date))
         self.assertEquals(response.status_code, 404)
 
         # If data falls in date range, data should be returned
-        start_date = start_date.strftime(settings.DATE_FORMAT)
-        end_date = end_date.strftime(settings.DATE_FORMAT)
+        start_date = start_date.strftime(settings.DATETIME_FORMAT)
+        end_date = end_date.strftime(settings.DATETIME_FORMAT)
         response = self.authenticated_get('%scourses/%s%s?start_date=%s&end_date=%s' % (
             self.api_root_path, self.course_id, self.path, start_date, end_date))
         self.assertEquals(response.status_code, 200)

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -142,10 +142,18 @@ class CourseViewTestCaseMixin(DemoCourseMixin):
         self.assertEquals(response.status_code, 404)
 
         # If data falls in date range, data should be returned
-        start_date = start_date.strftime(settings.DATETIME_FORMAT)
-        end_date = end_date.strftime(settings.DATETIME_FORMAT)
+        start = start_date.strftime(settings.DATETIME_FORMAT)
+        end = end_date.strftime(settings.DATETIME_FORMAT)
         response = self.authenticated_get('%scourses/%s%s?start_date=%s&end_date=%s' % (
-            self.api_root_path, self.course_id, self.path, start_date, end_date))
+            self.api_root_path, self.course_id, self.path, start, end))
+        self.assertEquals(response.status_code, 200)
+        self.assertListEqual(response.data, expected_response)
+
+        # Passing dates in DATE_FORMAT still works
+        start = start_date.strftime(settings.DATE_FORMAT)
+        end = end_date.strftime(settings.DATE_FORMAT)
+        response = self.authenticated_get('%scourses/%s%s?start_date=%s&end_date=%s' % (
+            self.api_root_path, self.course_id, self.path, start, end))
         self.assertEquals(response.status_code, 200)
         self.assertListEqual(response.data, expected_response)
 

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -30,11 +30,17 @@ class BaseCourseView(generics.ListAPIView):
         timezone = utc
 
         if start_date:
-            start_date = datetime.datetime.strptime(start_date, settings.DATE_FORMAT)
+            try:
+                start_date = datetime.datetime.strptime(start_date, settings.DATETIME_FORMAT)
+            except ValueError:
+                start_date = datetime.datetime.strptime(start_date, settings.DATE_FORMAT)
             start_date = make_aware(start_date, timezone)
 
         if end_date:
-            end_date = datetime.datetime.strptime(end_date, settings.DATE_FORMAT)
+            try:
+                end_date = datetime.datetime.strptime(end_date, settings.DATETIME_FORMAT)
+            except ValueError:
+                end_date = datetime.datetime.strptime(end_date, settings.DATE_FORMAT)
             end_date = make_aware(end_date, timezone)
 
         self.start_date = start_date

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -29,24 +29,19 @@ class BaseCourseView(generics.ListAPIView):
         end_date = request.QUERY_PARAMS.get('end_date')
         timezone = utc
 
-        if start_date:
-            try:
-                start_date = datetime.datetime.strptime(start_date, settings.DATETIME_FORMAT)
-            except ValueError:
-                start_date = datetime.datetime.strptime(start_date, settings.DATE_FORMAT)
-            start_date = make_aware(start_date, timezone)
-
-        if end_date:
-            try:
-                end_date = datetime.datetime.strptime(end_date, settings.DATETIME_FORMAT)
-            except ValueError:
-                end_date = datetime.datetime.strptime(end_date, settings.DATE_FORMAT)
-            end_date = make_aware(end_date, timezone)
-
-        self.start_date = start_date
-        self.end_date = end_date
+        self.start_date = self.parse_date(start_date, timezone)
+        self.end_date = self.parse_date(end_date, timezone)
 
         return super(BaseCourseView, self).get(request, *args, **kwargs)
+
+    def parse_date(self, date, timezone):
+        if date:
+            try:
+                date = datetime.datetime.strptime(date, settings.DATETIME_FORMAT)
+            except ValueError:
+                date = datetime.datetime.strptime(date, settings.DATE_FORMAT)
+            date = make_aware(date, timezone)
+        return date
 
     def apply_date_filtering(self, queryset):
         raise NotImplementedError


### PR DESCRIPTION
The [API docs](https://github.com/edx/edx-analytics-data-api/blob/master/analytics_data_api/v0/views/courses.py#L106) say that the date format for the course activity weekly endpoint is `YYYY-mm-ddTtttttt`, but the view was actually only accepting `YYYY-mm-dd`. All course API endpoints now support `YYYY-mm-ddTtttttt` (as well as `YYYY-mm-dd`).

@dsjen @ajpal 