### PR TITLE
Added 10 new userprofile fields to RosterEntry

### DIFF
--- a/analytics_data_api/management/commands/create_elasticsearch_learners_indices.py
+++ b/analytics_data_api/management/commands/create_elasticsearch_learners_indices.py
@@ -29,6 +29,9 @@ class Command(BaseCommand):
                                 'name': {
                                     'type': 'string'
                                 },
+                                'user_id': {
+                                    'type': 'integer', 'index': 'not_analyzed'
+                                },
                                 'username': {
                                     'type': 'string', 'index': 'not_analyzed'
                                 },
@@ -40,6 +43,33 @@ class Command(BaseCommand):
                                 },
                                 'enrollment_mode': {
                                     'type': 'string', 'index': 'not_analyzed', 'doc_values': True
+                                },
+                                'language': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'location': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'year_of_birth': {
+                                    'type': 'integer', 'index': 'not_analyzed'
+                                },
+                                'level_of_education': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'gender': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'mailing_address': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'city': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'country': {
+                                    'type': 'string', 'index': 'not_analyzed'
+                                },
+                                'goals': {
+                                    'type': 'string', 'index': 'not_analyzed'
                                 },
                                 'segments': {
                                     'type': 'string'

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -249,9 +249,19 @@ class RosterUpdate(DocType):
 class RosterEntry(DocType):
 
     course_id = String()
+    user_id = Integer()
     username = String()
     name = String()
     email = String()
+    language = String()
+    location = String()
+    year_of_birth = Integer()
+    level_of_education = String()
+    gender = String()
+    mailing_address = String()
+    city = String()
+    country = String()
+    goals = String()
     enrollment_mode = String()
     cohort = String()
     segments = String()  # segments is an array/list of strings

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -342,11 +342,21 @@ class LastUpdatedSerializer(serializers.Serializer):
 
 # pylint: disable=abstract-method
 class LearnerSerializer(serializers.Serializer):
+    user_id = serializers.IntegerField()
     username = serializers.CharField()
     enrollment_mode = serializers.CharField()
     name = serializers.CharField()
     account_url = serializers.SerializerMethodField()
     email = serializers.CharField()
+    language = serializers.CharField()
+    location = serializers.CharField()
+    year_of_birth = serializers.IntegerField()
+    level_of_education = serializers.CharField()
+    gender = serializers.CharField()
+    mailing_address = serializers.CharField()
+    city = serializers.CharField()
+    country = serializers.CharField()
+    goals = serializers.CharField()
     segments = serializers.SerializerMethodField()
     engagements = serializers.SerializerMethodField()
     enrollment_date = serializers.DateTimeField(format=settings.DATE_FORMAT)

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -47,6 +47,16 @@ class LearnerAPITestMixin(object):
             attempt_ratio_order=0,
             videos_viewed=0,
             enrollment_date='2015-01-28',
+            user_id=None,
+            language=None,
+            location=None,
+            year_of_birth=None,
+            level_of_education=None,
+            gender=None,
+            mailing_address=None,
+            city=None,
+            country=None,
+            goals=None,
     ):
         """Create a single learner roster entry in the elasticsearch index."""
         body = {
@@ -61,6 +71,16 @@ class LearnerAPITestMixin(object):
             'attempt_ratio_order': attempt_ratio_order,
             'videos_viewed': videos_viewed,
             'enrollment_date': enrollment_date,
+            "user_id": user_id,
+            "language": language,
+            "location": location,
+            "year_of_birth": year_of_birth,
+            "level_of_education": level_of_education,
+            "gender": gender,
+            "mailing_address": mailing_address,
+            "city": city,
+            "country": country,
+            "goals": goals,
         }
 
         # leave null fields from being stored in the index.  Otherwise, they will have
@@ -112,13 +132,20 @@ class LearnerTests(VerifyCourseIdMixin, LearnerAPITestMixin, TestCaseWithAuthent
     @ddt.data(
         ('ed_xavier', 'Edward Xavier', 'edX/DemoX/Demo_Course', 'honor', ['has_potential'], 'Team edX',
          43, 3, 6, 0, 8.4, 2, '2015-04-24', '2015-08-05'),
+        ('ed_xavier', 'Edward Xavier', 'edX/DemoX/Demo_Course', 'honor', ['has_potential'], 'Team edX',
+         43, 3, 6, 0, 8.4, 2, '2015-04-24', '2015-08-05',
+         10, 'French', 'Berlin', 1976, 'Bachelors', 'Male', '123 Sesame St', 'Springfield', 'France',
+         'I\'ve always wanted to play the piano.'),
         ('ed_xavier', 'Edward Xavier', 'edX/DemoX/Demo_Course', 'verified'),
     )
     @ddt.unpack
     def test_get_user(self, username, name, course_id, enrollment_mode, segments=None, cohort=None,
                       problems_attempted=None, problems_completed=None, videos_viewed=None,
                       discussion_contributions=None, problem_attempts_per_completed=None,
-                      attempt_ratio_order=None, enrollment_date=None, last_updated=None):
+                      attempt_ratio_order=None, enrollment_date=None, last_updated=None,
+                      user_id=None, language=None, location=None,
+                      year_of_birth=None, level_of_education=None, gender=None,
+                      mailing_address=None, city=None, country=None, goals=None):
 
         self.create_learners([{
             "username": username,
@@ -134,6 +161,16 @@ class LearnerTests(VerifyCourseIdMixin, LearnerAPITestMixin, TestCaseWithAuthent
             "problem_attempts_per_completed": problem_attempts_per_completed,
             "attempt_ratio_order": attempt_ratio_order,
             "enrollment_date": enrollment_date,
+            "user_id": user_id,
+            "language": language,
+            "location": location,
+            "year_of_birth": year_of_birth,
+            "level_of_education": level_of_education,
+            "gender": gender,
+            "mailing_address": mailing_address,
+            "city": city,
+            "country": country,
+            "goals": goals,
         }])
         self.create_update_index(last_updated)
 
@@ -157,6 +194,16 @@ class LearnerTests(VerifyCourseIdMixin, LearnerAPITestMixin, TestCaseWithAuthent
             },
             "enrollment_date": enrollment_date,
             "last_updated": last_updated,
+            "user_id": user_id,
+            "language": language,
+            "location": location,
+            "year_of_birth": year_of_birth,
+            "level_of_education": level_of_education,
+            "gender": gender,
+            "mailing_address": mailing_address,
+            "city": city,
+            "country": country,
+            "goals": goals,
         }
         self.assertDictEqual(expected, response.data)
 

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -62,6 +62,16 @@ class LearnerView(LastUpdateMixin, CourseViewMixin, generics.RetrieveAPIView):
               example, "audit" or "verified").
             * name: The learner's full name.
             * email: The learner's email address.
+            * user_id: The learner's numeric user ID.
+            * language: The learner's preferred language.
+            * location: The learner's reported location.
+            * year_of_birth: The learner's reported year of birth.
+            * level_of_education: The learner's reported level of education.
+            * gender: The learner's reported gender.
+            * mailing_address: The learner's reported mailing address.
+            * city: The learner's reported city.
+            * country: The learner's reported country.
+            * goals: The learner's reported goals.
             * segments: Classification, based on engagement, of this learner's
               work in this course (for example, "highly_engaged" or
               "struggling").
@@ -139,6 +149,16 @@ class LearnerListView(LastUpdateMixin, CourseViewMixin, generics.ListAPIView):
               example, "audit" or "verified").
             * name: The learner's full name.
             * email: The learner's email address.
+            * user_id: The learner's numeric user ID.
+            * language: The learner's preferred language.
+            * location: The learner's reported location.
+            * year_of_birth: The learner's reported year of birth.
+            * level_of_education: The learner's reported level of education.
+            * gender: The learner's reported gender.
+            * mailing_address: The learner's reported mailing address.
+            * city: The learner's reported city.
+            * country: The learner's reported country.
+            * goals: The learner's reported goals.
             * segments: Classification, based on engagement, of each learner's
               work in this course (for example, "highly_engaged" or
               "struggling").


### PR DESCRIPTION
Adds the following fields from the to the learner `RosterEntry` model, and its corresponding `LearnerSerializer`.

* user_id
* language
* location
* year_of_birth
* level_of_education
* gender
* mailing_address
* city
* country
* goals

**Discussions**: This change is related to [edx-analytics-data-api PR #128](https://github.com/edx/edx-analytics-data-api/pull/128), which has been discussed extensively with the Analytics team.

**Dependencies**: The data for this change depends on [edx-analytics-pipeline PR #272](https://github.com/edx/edx-analytics-pipeline/pull/272).  This change can be installed without updating the analytics pipeline; however the new fields won't be populated until the updated pipeline tasks .

**Sandbox URL**: TBD - sandbox is being provisioned.

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

1. See [edx-analytics-data-api PR #128](https://github.com/edx/edx-analytics-data-api/pull/128) for testing setup instructions.  
1. If you want to see the data flow through the pipeline to the Analytics API, follow the testing instructions from [edx-analytics-pipeline PR #272](https://github.com/edx/edx-analytics-pipeline/pull/272).  Without this step, the new fields will display in the Analytics API, but they will be empty.
1. View the new learner data fields via the Analytics API:
    1. Using the swagger.io UI:
        1. Visit [the swagger.io UI](http://localhost:8100)
        1. Enter your token in the "API Key" field, and click Explore
        1. Try out GET /authenticated request to ensure 200 response returned
        1. Try out GET /api/v0/learners/ request, with your `course_id` filled in.
    1. Using `curl`:

      ```
API_TOKEN="<your API token>"
COURSE_ID="<your URL-encoded course_id>"

curl -X GET --header "Authorization: Token $API_TOKEN" "http://localhost:8100/api/v0/learners/?course_id=$COURSE_ID"
```

**Reviewers**
- [x] @haikuginger
- [ ] @mulby 
- [ ] edX reviewer[s] TBD
