### PR TITLE
Adds endpoint to download course reports

### DIFF
--- a/analytics_data_api/utils.py
+++ b/analytics_data_api/utils.py
@@ -1,8 +1,36 @@
 import datetime
 from importlib import import_module
+import re
 
 from django.db.models import Q
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.exceptions import SuspiciousFileOperation, SuspiciousOperation
 from rest_framework.authtoken.models import Token
+from opaque_keys.edx.locator import CourseKey
+from opaque_keys import InvalidKeyError
+
+from analytics_data_api.v0.exceptions import (
+    ReportFileNotFoundError,
+    CannotCreateReportDownloadLinkError
+)
+
+
+def get_filename_safe_course_id(course_id, replacement_char='_'):
+    """
+    Create a representation of a course_id that can be used safely in a filepath.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+        filename = unicode(replacement_char).join([course_key.org, course_key.course, course_key.run])
+    except InvalidKeyError:
+        # If the course_id doesn't parse, we will still return a value here.
+        filename = course_id
+
+    # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
+    # We represent the first four with \w.
+    # TODO: Once we support courses with unicode characters, we will need to revisit this.
+    return re.sub(r'[^\w\.\-]', unicode(replacement_char), filename)
 
 
 def delete_user_auth_token(username):
@@ -84,3 +112,121 @@ def date_range(start_date, end_date, delta=datetime.timedelta(days=1)):
     while cur_date < end_date:
         yield cur_date
         cur_date += delta
+
+
+def get_course_report_download_details(course_id, report_name):
+    """
+    Determine the path that the report file should be located at,
+    then return metadata sufficient for downloading it.
+    """
+    report_location_template = getattr(
+        settings,
+        'COURSE_REPORT_FILE_LOCATION_TEMPLATE',
+        '{course_id}_{report_name}.csv'
+    )
+    # Course IDs contain characters that may not be valid in various
+    # filesystems; here we remove them before looking for the file or
+    # creating the downloadable filename.
+    course_id = get_filename_safe_course_id(course_id)
+    report_location = report_location_template.format(
+        course_id=course_id,
+        report_name=report_name
+    )
+    try:
+        if not default_storage.exists(report_location):
+            raise ReportFileNotFoundError(course_id=course_id, report_name=report_name)
+    except (
+            AttributeError,
+            NotImplementedError,
+            ImportError,
+            SuspiciousFileOperation,
+            SuspiciousOperation
+    ):
+        # Error out if:
+        # - We don't have a method to determine file existence
+        # - Such a method isn't implemented
+        # - We can't import the specified storage class
+        # - We don't have privileges for the specified file location
+        raise CannotCreateReportDownloadLinkError
+
+    try:
+        last_modified = default_storage.modified_time(report_location)
+    except (NotImplementedError, AttributeError):
+        last_modified = None
+
+    try:
+        download_size = default_storage.size(report_location)
+    except (NotImplementedError, AttributeError):
+        download_size = None
+
+    download_filename = '{}-{}-{}.csv'.format(
+        course_id,
+        report_name,
+        # We need a date for the filename; if we don't know when it was last modified,
+        # use the current date and time to stamp the filename.
+        (last_modified or datetime.datetime.utcnow()).strftime('%Y%m%dT%H%M%SZ')
+    )
+    url, expiration_date = get_file_object_url(report_location, download_filename)
+
+    details = {
+        'course_id': course_id,
+        'report_name': report_name,
+        'download_url': url
+    }
+    # These are all optional items that aren't guaranteed. The URL isn't guaranteed
+    # either, but we'll raise an exception earlier if we don't have it.
+    if last_modified is not None:
+        details.update({'last_modified': last_modified.strftime(settings.DATETIME_FORMAT)})
+    if expiration_date is not None:
+        details.update({'expiration_date': expiration_date.strftime(settings.DATETIME_FORMAT)})
+    if download_size is not None:
+        details.update({'file_size': download_size})
+    return details
+
+
+def get_file_object_url(filename, download_filename):
+    """
+    Retrieve a download URL for the file, as well as a datetime object
+    indicating when the URL expires.
+
+    We need to pass extra details to the URL method, above and beyond just the
+    file location, to give us what we need.
+
+    This method supports S3 storage's optional response parameters that allow
+    us to set expiry time, as well as content disposition and content type
+    on any download made using the generated link.
+    """
+    # Default to expiring the link after two minutes
+    expire_length = getattr(settings, 'COURSE_REPORT_DOWNLOAD_EXPIRY_TIME', 120)
+    expires_at = get_expiration_date(expire_length)
+    try:
+        url = default_storage.url(
+            name=filename,
+            response_headers={
+                'response-content-disposition': 'attachment; filename={}'.format(download_filename),
+                'response-content-type': 'text/csv',
+                # The Expires header requires a very particular timestamp format
+                'response-expires': expires_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
+            },
+            expire=expire_length
+        )
+    except TypeError:
+        # We got a TypeError when calling `.url()`; typically, this means that the arguments
+        # we passed aren't allowed. Retry with no extra arguments.
+        try:
+            url = default_storage.url(name=filename)
+            expires_at = None
+        except (AttributeError, TypeError, NotImplementedError):
+            # Another error, for unknown reasons. Can't recover from this; fail fast
+            raise CannotCreateReportDownloadLinkError
+    except (AttributeError, NotImplementedError):
+        # Either we can't find a .url() method, or we can't use it. Raise an exception.
+        raise CannotCreateReportDownloadLinkError
+    return url, expires_at
+
+
+def get_expiration_date(seconds):
+    """
+    Determine when a given link will expire, based on a given lifetime
+    """
+    return datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds)

--- a/analytics_data_api/v0/exceptions.py
+++ b/analytics_data_api/v0/exceptions.py
@@ -72,3 +72,26 @@ class ParameterValueError(BaseError):
     def __init__(self, message, *args, **kwargs):
         super(ParameterValueError, self).__init__(*args, **kwargs)
         self.message = message
+
+
+class ReportFileNotFoundError(BaseError):
+    """
+    Raise if we couldn't find the file we need to produce the report
+    """
+    def __init__(self, *args, **kwargs):
+        course_id = kwargs.pop('course_id')
+        report_name = kwargs.pop('report_name')
+        super(ReportFileNotFoundError, self).__init__(*args, **kwargs)
+        self.message = self.message_template.format(course_id=course_id, report_name=report_name)
+
+    @property
+    def message_template(self):
+        return 'Could not find report \'{report_name}\' for course {course_id}.'
+
+
+class CannotCreateReportDownloadLinkError(BaseError):
+    """
+    Raise if we cannot create a link for the file to be downloaded
+    """
+
+    message = 'Could not create a downloadable link to the report.'

--- a/analytics_data_api/v0/middleware.py
+++ b/analytics_data_api/v0/middleware.py
@@ -8,6 +8,8 @@ from analytics_data_api.v0.exceptions import (
     LearnerEngagementTimelineNotFoundError,
     LearnerNotFoundError,
     ParameterValueError,
+    ReportFileNotFoundError,
+    CannotCreateReportDownloadLinkError,
 )
 
 
@@ -129,3 +131,39 @@ class ParameterValueErrorMiddleware(BaseProcessErrorMiddleware):
     @property
     def status_code(self):
         return status.HTTP_400_BAD_REQUEST
+
+
+class ReportFileNotFoundErrorMiddleware(BaseProcessErrorMiddleware):
+    """
+    Raise 404 if the report file isn't present
+    """
+
+    @property
+    def error(self):
+        return ReportFileNotFoundError
+
+    @property
+    def error_code(self):
+        return 'report_file_not_found'
+
+    @property
+    def status_code(self):
+        return status.HTTP_404_NOT_FOUND
+
+
+class CannotCreateDownloadLinkErrorMiddleware(BaseProcessErrorMiddleware):
+    """
+    Raise 501 if the filesystem doesn't support creating download links
+    """
+
+    @property
+    def error(self):
+        return CannotCreateReportDownloadLinkError
+
+    @property
+    def error_code(self):
+        return 'cannot_create_report_download_link'
+
+    @property
+    def status_code(self):
+        return status.HTTP_501_NOT_IMPLEMENTED

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -3,7 +3,10 @@ import json
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 
+from analytics_data_api.utils import get_filename_safe_course_id
+
 DEMO_COURSE_ID = u'course-v1:edX+DemoX+Demo_2014'
+SANITIZED_DEMO_COURSE_ID = get_filename_safe_course_id(DEMO_COURSE_ID)
 
 
 class DemoCourseMixin(object):

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -14,7 +14,8 @@ COURSE_URLS = [
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
     ('problems_and_tags', views.ProblemsAndTagsListView, 'problems_and_tags'),
-    ('videos', views.VideosListView, 'videos')
+    ('videos', views.VideosListView, 'videos'),
+    ('reports/(?P<report_name>[a-zA-Z0-9_]+)', views.ReportDownloadView, 'reports'),
 ]
 
 urlpatterns = []

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -799,9 +799,7 @@ class ReportDownloadView(APIView):
             * expiration_date: The date through which the link will be valid
             * file_size: The size in bytes of the CSV download
     """
-    enabled_reports = (
-        'problem_response'
-    )
+    enabled_reports = settings.ENABLED_REPORT_IDENTIFIERS
 
     def get(self, _request, course_id, report_name):
         if report_name in self.enabled_reports:

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -177,6 +177,8 @@ MIDDLEWARE_CLASSES = (
     'analytics_data_api.v0.middleware.CourseNotSpecifiedErrorMiddleware',
     'analytics_data_api.v0.middleware.CourseKeyMalformedErrorMiddleware',
     'analytics_data_api.v0.middleware.ParameterValueErrorMiddleware',
+    'analytics_data_api.v0.middleware.ReportFileNotFoundErrorMiddleware',
+    'analytics_data_api.v0.middleware.CannotCreateDownloadLinkErrorMiddleware',
 )
 ########## END MIDDLEWARE CONFIGURATION
 
@@ -204,6 +206,7 @@ THIRD_PARTY_APPS = (
     'rest_framework.authtoken',
     'rest_framework_swagger',
     'django_countries',
+    'storages'
 )
 
 LOCAL_APPS = (
@@ -305,6 +308,12 @@ ENABLE_ADMIN_SITE = False
 
 # base url to generate link to user api
 LMS_USER_ACCOUNT_BASE_URL = None
+
+# storage settings for report downloads
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+MEDIA_ROOT = '/edx/app/analytics_api/analytics_api/static/reports'
+MEDIA_URL = 'http://localhost:8100/static/reports/'
+COURSE_REPORT_FILE_LOCATION_TEMPLATE = '{course_id}_{report_name}.csv'
 
 ########## END ANALYTICS DATA API CONFIGURATION
 

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -85,15 +85,6 @@ USE_TZ = True
 ########## END GENERAL CONFIGURATION
 
 
-########## MEDIA CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = normpath(join(SITE_ROOT, 'media'))
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = '/media/'
-########## END MEDIA CONFIGURATION
-
-
 ########## STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = normpath(join(SITE_ROOT, 'assets'))
@@ -309,11 +300,12 @@ ENABLE_ADMIN_SITE = False
 # base url to generate link to user api
 LMS_USER_ACCOUNT_BASE_URL = None
 
-# storage settings for report downloads
+# settings for report downloads
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-MEDIA_ROOT = '/edx/app/analytics_api/analytics_api/static/reports'
+MEDIA_ROOT = normpath(join(SITE_ROOT, 'static', 'reports'))
 MEDIA_URL = 'http://localhost:8100/static/reports/'
 COURSE_REPORT_FILE_LOCATION_TEMPLATE = '{course_id}_{report_name}.csv'
+ENABLED_REPORT_IDENTIFIERS = ('problem_response',)
 
 ########## END ANALYTICS DATA API CONFIGURATION
 

--- a/analyticsdataserver/settings/production.py
+++ b/analyticsdataserver/settings/production.py
@@ -31,7 +31,10 @@ CONFIG_FILE=get_env_setting('ANALYTICS_API_CFG')
 with open(CONFIG_FILE) as f:
   config_from_yaml = yaml.load(f)
 
+REPORT_DOWNLOAD_BACKEND = config_from_yaml.pop('REPORT_DOWNLOAD_BACKEND', {})
+
 vars().update(config_from_yaml)
+vars().update(REPORT_DOWNLOAD_BACKEND)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -29,3 +29,14 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 ELASTICSEARCH_LEARNERS_HOST = 'http://localhost:9223/'
 ELASTICSEARCH_LEARNERS_INDEX = 'roster_test'
 ELASTICSEARCH_LEARNERS_UPDATE_INDEX = 'index_update_test'
+
+# Default the django-storage settings so we can test easily
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+AWS_ACCESS_KEY_ID = 'xxxxx'
+AWS_SECRET_ACCESS_KEY = 'xxxxx'
+AWS_STORAGE_BUCKET_NAME = 'fake-bucket'
+FTP_STORAGE_LOCATION = 'ftp://localhost:80/path'
+
+# Default settings for report download endpoint
+COURSE_REPORT_FILE_LOCATION_TEMPLATE = '/{course_id}_{report_name}.csv'
+COURSE_REPORT_DOWNLOAD_EXPIRY_TIME = 120

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,4 @@ elasticsearch-dsl==0.0.11           # Apache 2.0
 Markdown==2.6.6    					# BSD
 
 -e git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
+django-storages==1.4.1              # BSD


### PR DESCRIPTION
This change creates a new endpoint at `/courses/{course_id}/reports/{report_name}/` that can be queried to create and provide a temporary downloadable link to an AWS-hosted CSV report.

- Currently, only the S3 storage architecture is supported as a host for these files
- Currently, only the `problem_response` report is supported as a download.

**Dependencies**: None

**Sandbox URL**: N/A

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

1. In an AWS S3 bucket, upload a report CSV. The filename (including path) should include the name of the report and the course ID of the course it was run on. E.g:

    `/course-v1:edX+DemoX+Demo_Course/problem_response.csv`

    Make a note of this location and bucket.

2. Make a note of your AWS access key ID and AWS secret access key

3. Determine the amount of time, in seconds, you'd like links to remain active after creation. In real-world use, this endpoint will be consumed by Javascript that than immediately downloads the file to the user's computer, so more than a few seconds to a minute shouldn't be necessary. In testing, you may want to allow yourself more time.

4. In an analytics devstack, checkout this branch and install requirements. This branch updates the version of `boto` required, and adds a requirement for `django-storages`.

5. Add the following to your `/edx/etc/analytics_api.yml` file:

    ```yaml
DEFAULT_FILE_STORAGE: storages.backends.s3boto.S3BotoStorage
AWS_ACCESS_KEY_ID: XXXXXXXXXXXXXX
AWS_SECRET_ACCESS_KEY: XXXXXXXXXXXXXX
AWS_STORAGE_BUCKET_NAME: report-download-bucket
COURSE_REPORT_FILE_LOCATION_TEMPLATE: '/{course_id}/{report_name}.csv'
COURSE_REPORT_DOWNLOAD_EXPIRY_TIME: 120
```
    Substitute your own AWS details for the above. For the `COURSE_REPORT_FILE_LOCATION_TEMPLATE` variable, note that this should be a Python format string; the endpoint will use this to locate the correct file for any given course/report combination. The `COURSE_REPORT_DOWNLOAD_EXPIRY_TIME` is given in seconds; update this to select whatever value you'd like - the default is two minutes.

6. Run the analytics API with `./manage.py runserver 0.0.0.0:8100 --insecure` or similar.

7. Using the Swagger console or `curl`, hit the endpoint and note that the response, among other details, provides you with a signed URL you can use to download the CSV file you uploaded directly. 

8. Note that when this link is used in a browser, it immediately downloads as a `text/csv` MIME type, and that the name of the downloaded file contains relevant information, such as the course ID, the name of the report, and the date the report was generated/last modified.

**Author notes and concerns**:

1. Right now, this endpoint supports a limited number of use cases, but there's no reason it can't be expanded to support other reports.

2. At the moment, the list of report(s) that can be downloaded is hardcoded, but it's a valid option to move this to a variable in `analytics_api.yml`.

**Reviewers**
- [x] @pomegranited
- [ ] @mulby 