### PR TITLE
Fixed serialization of problem part IDs and tags.

### DIFF
--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -56,7 +56,7 @@ class ProblemSerializer(serializers.Serializer):
     module_id = serializers.CharField(required=True)
     total_submissions = serializers.IntegerField(default=0)
     correct_submissions = serializers.IntegerField(default=0)
-    part_ids = serializers.CharField()
+    part_ids = serializers.ListField(child=serializers.CharField())
     created = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
 
 
@@ -69,8 +69,11 @@ class ProblemsAndTagsSerializer(serializers.Serializer):
     module_id = serializers.CharField(required=True)
     total_submissions = serializers.IntegerField(default=0)
     correct_submissions = serializers.IntegerField(default=0)
-    tags = serializers.CharField()
+    tags = serializers.SerializerMethodField()
     created = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
+
+    def get_tags(self, obj):
+        return obj.get('tags', None)
 
 
 class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedField):

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -628,14 +628,14 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
                 'module_id': module_id,
                 'total_submissions': 150,
                 'correct_submissions': 50,
-                'part_ids': unicode([o1.part_id, o3.part_id]),
+                'part_ids': [unicode(o1.part_id), unicode(o3.part_id)],
                 'created': alt_created.strftime(settings.DATETIME_FORMAT)
             },
             {
                 'module_id': alt_module_id,
                 'total_submissions': 100,
                 'correct_submissions': 100,
-                'part_ids': unicode([o2.part_id]),
+                'part_ids': [unicode(o2.part_id)],
                 'created': unicode(created.strftime(settings.DATETIME_FORMAT))
             }
         ]
@@ -699,19 +699,19 @@ class CourseProblemsAndTagsListViewTests(DemoCourseMixin, TestCaseWithAuthentica
                 'module_id': module_id,
                 'total_submissions': 11,
                 'correct_submissions': 4,
-                'tags': unicode({
+                'tags': {
                     u'difficulty': u'Easy',
                     u'learning_outcome': u'Learned a few things',
-                }),
+                },
                 'created': alt_created.strftime(settings.DATETIME_FORMAT)
             },
             {
                 'module_id': alt_module_id,
                 'total_submissions': 4,
                 'correct_submissions': 0,
-                'tags': unicode({
+                'tags': {
                     u'learning_outcome': u'Learned everything',
-                }),
+                },
                 'created': created.strftime(settings.DATETIME_FORMAT)
             }
         ]


### PR DESCRIPTION
I misunderstood what was happening during the DRF upgrade with serialization of lists.  This fixes the JSON so that the entire object isn't returned as a string.

Please review!