### PR TITLE
Fix: add "--run-syncdb" to the migrate Make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ quality:
 validate: test.requirements test quality
 
 migrate:
-	$(foreach db_name,$(DATABASES),./manage.py migrate --noinput --database=$(db_name);)
+	$(foreach db_name,$(DATABASES),./manage.py migrate --noinput --run-syncdb --database=$(db_name);)
 
 loaddata: migrate
 	python manage.py loaddata problem_response_answer_distribution --database=analytics


### PR DESCRIPTION
I missed this in the Django 1.9 upgrade: in 1.9, syncdb was turned off by default on the `migrate` command. This was preventing all of the analytics tables from being created in the analytics.db when it is first created (which happens in Travis every build).

We'll know this fix worked once we merge this, run the acceptance tests in insights again, and they pass.