### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ djangorestframework==3.4.6			# BSD
 django-rest-swagger==0.3.8  		# BSD
 djangorestframework-csv==1.4.1		# BSD
 django-countries==4.0               # MIT
-edx-django-release-util==0.1.0
+edx-django-release-util==0.1.1
 elasticsearch-dsl==0.0.11           # Apache 2.0
 ordered-set==2.0.1                  # MIT
 


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.1.

@edx/analytics  Please review and tag appropriate parties.