### PR TITLE
Use date instead of datetime in ModuleEngagementMetricRanges.

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -270,5 +270,5 @@ class Command(BaseCommand):
         self.generate_video_data(course_id, video_id, video_module_id)
         self.generate_video_timeline_data(video_id)
         self.generate_learner_engagement_data(course_id, username, start_date, end_date)
-        self.generate_learner_engagement_range_data(course_id, start_date, end_date)
+        self.generate_learner_engagement_range_data(course_id, start_date.date(), end_date.date())
         self.generate_tags_distribution_data(course_id)

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -495,9 +495,9 @@ class ModuleEngagementMetricRanges(models.Model):
     """
 
     course_id = models.CharField(db_index=True, max_length=255)
-    start_date = models.DateTimeField()
+    start_date = models.DateField()
     # This is a left-closed interval. No data from the end_date is included in the analysis.
-    end_date = models.DateTimeField()
+    end_date = models.DateField()
     metric = models.CharField(max_length=50)
     range_type = models.CharField(max_length=50)
     # Also a left-closed interval, so any metric whose value is equal to the high_value

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -447,8 +447,8 @@ class EngagementDaySerializer(serializers.Serializer):
 
 # pylint: disable=abstract-method
 class DateRangeSerializer(serializers.Serializer):
-    start = serializers.DateTimeField(source='start_date', format=settings.DATE_FORMAT)
-    end = serializers.DateTimeField(source='end_date', format=settings.DATE_FORMAT)
+    start = serializers.DateField(source='start_date', format=settings.DATE_FORMAT)
+    end = serializers.DateField(source='end_date', format=settings.DATE_FORMAT)
 
 
 # pylint: disable=abstract-method

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -10,7 +10,6 @@ import ddt
 from django_dynamic_fixture import G
 from elasticsearch import Elasticsearch
 from mock import patch, Mock
-import pytz
 from rest_framework import status
 
 from django.conf import settings
@@ -784,8 +783,8 @@ class CourseLearnerMetadataTests(DemoCourseMixin, VerifyCourseIdMixin,
 
     def test_one_engagement_range(self):
         metric_type = 'problems_completed'
-        start_date = datetime.datetime(2015, 7, 1, tzinfo=pytz.utc)
-        end_date = datetime.datetime(2015, 7, 21, tzinfo=pytz.utc)
+        start_date = datetime.date(2015, 7, 1)
+        end_date = datetime.date(2015, 7, 21)
         G(ModuleEngagementMetricRanges, course_id=self.course_id, start_date=start_date, end_date=end_date,
           metric=metric_type, range_type='normal', low_value=90, high_value=6120)
         expected_ranges = self.empty_engagement_ranges
@@ -807,8 +806,8 @@ class CourseLearnerMetadataTests(DemoCourseMixin, VerifyCourseIdMixin,
 
     def _get_full_engagement_ranges(self):
         """ Populates a full set of engagement ranges and returns the expected engagement ranges. """
-        start_date = datetime.datetime(2015, 7, 1, tzinfo=pytz.utc)
-        end_date = datetime.datetime(2015, 7, 21, tzinfo=pytz.utc)
+        start_date = datetime.date(2015, 7, 1)
+        end_date = datetime.date(2015, 7, 21)
 
         expected = {
             'engagement_ranges': {


### PR DESCRIPTION
* Fixes [AN-7828](https://openedx.atlassian.net/browse/AN-7828).
* Replace datetimes with dates in generated data, unit tests, and model fields for ModuleEngagementMetricRanges.

Both the locally generated data and the unit tests were generating dates as datetimes, and we thus never noticed them locally.  This problem manifests on stage because stage because the pipeline generates the data.  We failed to comply with the contract!