### PR TITLE
AN-7880 Uncomment including "posted_forum" events

### DIFF
--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -300,13 +300,13 @@ class CourseActivityWeeklySerializer(serializers.ModelSerializer):
     any = serializers.IntegerField(required=False)
     attempted_problem = serializers.IntegerField(required=False)
     played_video = serializers.IntegerField(required=False)
-    # posted_forum = serializers.IntegerField(required=False)
+    posted_forum = serializers.IntegerField(required=False)
     created = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
 
     class Meta(object):
         model = models.CourseActivityWeekly
-        # TODO: Add 'posted_forum' here to restore forum data
-        fields = ('interval_start', 'interval_end', 'course_id', 'any', 'attempted_problem', 'played_video', 'created')
+        fields = ('interval_start', 'interval_end', 'course_id', 'any', 'attempted_problem', 'played_video',
+                  'posted_forum', 'created')
 
 
 class VideoSerializer(ModelSerializerWithCreatedField):

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -165,9 +165,9 @@ class CourseActivityLastWeekTest(DemoCourseMixin, TestCaseWithAuthentication):
         course_id = course_id or self.course_id
         interval_start = datetime.datetime(2014, 1, 1, tzinfo=pytz.utc)
         interval_end = interval_start + datetime.timedelta(weeks=1)
-        # G(models.CourseActivityWeekly, course_id=course_id, interval_start=interval_start,
-        # interval_end=interval_end,
-        # activity_type='POSTED_FORUM', count=100)
+        G(models.CourseActivityWeekly, course_id=course_id, interval_start=interval_start,
+        interval_end=interval_end,
+        activity_type='POSTED_FORUM', count=100)
         G(models.CourseActivityWeekly, course_id=course_id, interval_start=interval_start,
           interval_end=interval_end,
           activity_type='ATTEMPTED_PROBLEM', count=200)

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -166,8 +166,7 @@ class CourseActivityLastWeekTest(DemoCourseMixin, TestCaseWithAuthentication):
         interval_start = datetime.datetime(2014, 1, 1, tzinfo=pytz.utc)
         interval_end = interval_start + datetime.timedelta(weeks=1)
         G(models.CourseActivityWeekly, course_id=course_id, interval_start=interval_start,
-        interval_end=interval_end,
-        activity_type='POSTED_FORUM', count=100)
+          interval_end=interval_end, activity_type='POSTED_FORUM', count=100)
         G(models.CourseActivityWeekly, course_id=course_id, interval_start=interval_start,
           interval_end=interval_end,
           activity_type='ATTEMPTED_PROBLEM', count=200)


### PR DESCRIPTION
Now that we have "posted_forum" category events in the course_activity table again, let's re-enable processing those events in the Data API serializer.

Tested locally in analyticstack.

This will pass the data to Insights and we should be able to just flip the switch to get forum events in the graphs and tables.