### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,5 +13,5 @@ ordered-set==2.0.1                  # MIT
 Markdown==2.6.6    					# BSD
 
 edx-ccx-keys==0.2.1
-edx-django-release-util==0.1.2
+edx-django-release-util==0.2.0
 edx-opaque-keys==0.4.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.2.0.

@edx-ops/pipeline-team Please review and tag appropriate parties.