### PR TITLE
Updated field names in course summaries.

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -140,9 +140,9 @@ class Command(BaseCommand):
             cumulative_count = count + random.randint(0, 100)
             models.CourseMetaSummaryEnrollment.objects.create(
                 course_id=course_id, catalog_course_title='Demo Course', catalog_course='Demo_Course',
-                start_date=timezone.now() - datetime.timedelta(weeks=6),
-                end_date=timezone.now() + datetime.timedelta(weeks=10),
-                pacing_type='self_paced', availability='Current', mode=mode, count=count,
+                start_time=timezone.now() - datetime.timedelta(weeks=6),
+                end_time=timezone.now() + datetime.timedelta(weeks=10),
+                pacing_type='self_paced', availability='Current', enrollment_mode=mode, count=count,
                 cumulative_count=cumulative_count, count_change_7_days=random.randint(-50, 50))
 
         progress.update(1)

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -70,11 +70,11 @@ class CourseEnrollmentModeDaily(BaseCourseEnrollment):
 class CourseMetaSummaryEnrollment(BaseCourseModel):
     catalog_course_title = models.CharField(db_index=True, max_length=255)
     catalog_course = models.CharField(db_index=True, max_length=255)
-    start_date = models.DateTimeField()
-    end_date = models.DateTimeField()
+    start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
     pacing_type = models.CharField(db_index=True, max_length=255)
     availability = models.CharField(db_index=True, max_length=255)
-    mode = models.CharField(max_length=255)
+    enrollment_mode = models.CharField(max_length=255)
     count = models.IntegerField(null=False)
     cumulative_count = models.IntegerField(null=False)
     count_change_7_days = models.IntegerField(default=0)
@@ -82,7 +82,7 @@ class CourseMetaSummaryEnrollment(BaseCourseModel):
     class Meta(BaseCourseModel.Meta):
         db_table = 'course_meta_summary_enrollment'
         ordering = ('course_id',)
-        unique_together = [('course_id', 'mode',)]
+        unique_together = [('course_id', 'enrollment_mode',)]
 
 
 class CourseEnrollmentByBirthYear(BaseCourseEnrollment):

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -539,18 +539,19 @@ class CourseMetaSummaryEnrollmentSerializer(ModelSerializerWithCreatedField, Dyn
     course_id = serializers.CharField()
     catalog_course_title = serializers.CharField()
     catalog_course = serializers.CharField()
-    start_date = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
-    end_date = serializers.DateTimeField(format=settings.DATETIME_FORMAT)
+    start_date = serializers.DateTimeField(source='start_time', format=settings.DATETIME_FORMAT)
+    end_date = serializers.DateTimeField(source='end_time', format=settings.DATETIME_FORMAT)
     pacing_type = serializers.CharField()
     availability = serializers.CharField()
     count = serializers.IntegerField(default=0)
     cumulative_count = serializers.IntegerField(default=0)
     count_change_7_days = serializers.IntegerField(default=0)
-    modes = serializers.SerializerMethodField()
+    enrollment_modes = serializers.SerializerMethodField()
 
-    def get_modes(self, obj):
-        return obj.get('modes', None)
+    def get_enrollment_modes(self, obj):
+        return obj.get('enrollment_modes', None)
 
     class Meta(object):
         model = models.CourseMetaSummaryEnrollment
-        exclude = ('id', 'mode')
+        # start_date and end_date used instead of start_time and end_time
+        exclude = ('id', 'start_time', 'end_time', 'enrollment_mode')

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -45,9 +45,9 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
         for course_id in course_ids:
             for mode in modes:
                 G(self.model, course_id=course_id, catalog_course_title='Title', catalog_course='Catalog',
-                  start_date=datetime.datetime(2016, 10, 11, tzinfo=pytz.utc),
-                  end_date=datetime.datetime(2016, 12, 18, tzinfo=pytz.utc),
-                  pacing_type='instructor', availability='current', mode=mode,
+                  start_time=datetime.datetime(2016, 10, 11, tzinfo=pytz.utc),
+                  end_time=datetime.datetime(2016, 12, 18, tzinfo=pytz.utc),
+                  pacing_type='instructor', availability='current', enrollment_mode=mode,
                   count=5, cumulative_count=10, count_change_7_days=1, create=self.now,)
 
     def expected_summary(self, course_id, modes=None):
@@ -67,28 +67,28 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
             'end_date': datetime.datetime(2016, 12, 18, tzinfo=pytz.utc).strftime(settings.DATETIME_FORMAT),
             'pacing_type': 'instructor',
             'availability': 'current',
-            'modes': {},
+            'enrollment_modes': {},
             'count': count_factor * num_modes,
             'cumulative_count': cumulative_count_factor * num_modes,
             'count_change_7_days': count_change_factor * num_modes,
             'created': self.now.strftime(settings.DATETIME_FORMAT),
         }
-        summary['modes'].update({
+        summary['enrollment_modes'].update({
             mode: {
                 'count': count_factor,
                 'cumulative_count': cumulative_count_factor,
                 'count_change_7_days': count_change_factor,
             } for mode in modes
         })
-        summary['modes'].update({
+        summary['enrollment_modes'].update({
             mode: {
                 'count': 0,
                 'cumulative_count': 0,
                 'count_change_7_days': 0,
             } for mode in set(enrollment_modes.ALL) - set(modes)
         })
-        no_prof = summary['modes'].pop(enrollment_modes.PROFESSIONAL_NO_ID)
-        prof = summary['modes'].get(enrollment_modes.PROFESSIONAL)
+        no_prof = summary['enrollment_modes'].pop(enrollment_modes.PROFESSIONAL_NO_ID)
+        prof = summary['enrollment_modes'].get(enrollment_modes.PROFESSIONAL)
         prof.update({
             'count': prof['count'] + no_prof['count'],
             'cumulative_count': prof['cumulative_count'] + no_prof['cumulative_count'],
@@ -121,7 +121,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
 
     @ddt.data(
         ['availability'],
-        ['modes', 'course_id'],
+        ['enrollment_mode', 'course_id'],
     )
     def test_fields(self, fields):
         self.generate_data()

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -35,7 +35,7 @@ class CourseSummariesView(generics.ListAPIView):
             * count: The total count of currently enrolled learners across modes.
             * cumulative_count: The total cumulative total of all users ever enrolled across modes.
             * count_change_7_days: Total difference in enrollment counts over the past 7 days across modes.
-            * modes: For each enrollment mode, the count, cumulative_count, and count_change_7_days.
+            * enrollment_modes: For each enrollment mode, the count, cumulative_count, and count_change_7_days.
             * created: The date the counts were computed.
 
     **Parameters**
@@ -78,10 +78,10 @@ class CourseSummariesView(generics.ListAPIView):
         summary = {
             'course_id': course_id,
             'created': None,
-            'modes': {},
+            'enrollment_modes': {},
         }
         summary.update({field: 0 for field in count_fields})
-        summary['modes'].update({
+        summary['enrollment_modes'].update({
             mode: {
                 count_field: 0 for count_field in count_fields
             } for mode in enrollment_modes.ALL
@@ -97,11 +97,11 @@ class CourseSummariesView(generics.ListAPIView):
 
             # aggregate the enrollment counts for each mode
             for summary in summaries:
-                summary_meta_fields = ['catalog_course_title', 'catalog_course', 'start_date', 'end_date',
+                summary_meta_fields = ['catalog_course_title', 'catalog_course', 'start_time', 'end_time',
                                        'pacing_type', 'availability']
                 item.update({field: getattr(summary, field) for field in summary_meta_fields})
-                item['modes'].update({
-                    summary.mode: {field: getattr(summary, field) for field in count_fields}
+                item['enrollment_modes'].update({
+                    summary.enrollment_mode: {field: getattr(summary, field) for field in count_fields}
                 })
 
                 # treat the most recent as the authoritative created date -- should be all the same
@@ -111,7 +111,7 @@ class CourseSummariesView(generics.ListAPIView):
                 item.update({field: item[field] + getattr(summary, field) for field in count_fields})
 
             # Merge professional with non verified professional
-            modes = item['modes']
+            modes = item['enrollment_modes']
             prof_no_id_mode = modes.pop(enrollment_modes.PROFESSIONAL_NO_ID, {})
             prof_mode = modes[enrollment_modes.PROFESSIONAL]
             for count_key in count_fields:


### PR DESCRIPTION
* renamed start/end_time to start/end_date
* renamed modes to enrollment_modes

I misnamed the columns that was generated by the data pipeline.  This PR fixes that.