### PR TITLE
API to fetch orgs and tags

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -157,6 +157,7 @@ class ProblemsAndTags(BaseCourseModel):
     class Meta(BaseCourseModel.Meta):
         db_table = 'tags_distribution'
 
+    org_id = models.CharField(db_index=True, max_length=255)
     module_id = models.CharField(db_index=True, max_length=255)
     tag_name = models.CharField(max_length=255)
     tag_value = models.CharField(max_length=255)

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -75,6 +75,13 @@ class ProblemsAndTagsSerializer(serializers.Serializer):
         return obj.get('tags', None)
 
 
+class CoursesProblemsAndTagsSerializer(ProblemsAndTagsSerializer):
+    """
+    Serializer for problems and tags.
+    """
+    course_id = serializers.CharField(required=True)
+
+
 class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedField):
     """
     Representation of the Answer Distribution table, without id.

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -6,6 +6,7 @@ COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+[/+][^/+]+[/+][^/]+)'
 
 urlpatterns = [
     url(r'^courses/', include('analytics_data_api.v0.urls.courses', 'courses')),
+    url(r'^orgs/', include('analytics_data_api.v0.urls.orgs', namespace='orgs')),
     url(r'^problems/', include('analytics_data_api.v0.urls.problems', 'problems')),
     url(r'^videos/', include('analytics_data_api.v0.urls.videos', 'videos')),
     url('^', include('analytics_data_api.v0.urls.learners', 'learners')),

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -13,7 +13,7 @@ COURSE_URLS = [
     ('enrollment/gender', views.CourseEnrollmentByGenderView, 'enrollment_by_gender'),
     ('enrollment/location', views.CourseEnrollmentByLocationView, 'enrollment_by_location'),
     ('problems', views.ProblemsListView, 'problems'),
-    ('problems_and_tags', views.ProblemsAndTagsListView, 'problems_and_tags'),
+    ('problems_and_tags', views.ProblemsAndTagsListView, 'course_problems_and_tags'),
     ('videos', views.VideosListView, 'videos'),
     ('reports/(?P<report_name>[a-zA-Z0-9_]+)', views.ReportDownloadView, 'reports'),
 ]

--- a/analytics_data_api/v0/urls/orgs.py
+++ b/analytics_data_api/v0/urls/orgs.py
@@ -1,0 +1,15 @@
+from django.conf.urls import patterns, url
+
+from analytics_data_api.v0.views import orgs as views
+
+ORG_ID_PATTERN = r'(?P<org_id>[^/+]+)'
+
+COURSE_URLS = [
+    ('problems_and_tags', views.ProblemsAndTagsListView, 'org_problems_and_tags'),
+]
+
+urlpatterns = []
+
+for path, view, name in COURSE_URLS:
+    regex = r'^{0}/{1}/$'.format(ORG_ID_PATTERN, path)
+    urlpatterns += patterns('', url(regex, view.as_view(), name=name))

--- a/analytics_data_api/v0/views/orgs.py
+++ b/analytics_data_api/v0/views/orgs.py
@@ -1,0 +1,66 @@
+from rest_framework import generics
+from analytics_data_api.v0 import models, serializers
+
+
+class BaseOrgView(generics.ListAPIView):
+    org_id = None
+
+    def get(self, request, *args, **kwargs):
+        self.org_id = self.kwargs.get('org_id')
+        return super(BaseOrgView, self).get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        queryset = self.model.objects.filter(org_id=self.org_id)
+        return queryset
+
+
+# pylint: disable=abstract-method
+class ProblemsAndTagsListView(BaseOrgView):
+    """
+    Get the courses and the problems with the connected tags.
+
+    **Example request**
+
+        GET /api/v0/orgs/{org_id}/problems_and_tags/
+
+    **Response Values**
+
+        Returns a collection of submission counts and tags for each problem. Each collection contains:
+
+            * course_id: The ID of the course.
+            * module_id: The ID of the problem.
+            * total_submissions: Total number of submissions.
+            * correct_submissions: Total number of *correct* submissions.
+            * tags: Dictionary that contains pairs "tag key: [tag value_1, tag_value_2, ..., tag_value_n]".
+    """
+    serializer_class = serializers.CoursesProblemsAndTagsSerializer
+    allow_empty = False
+    model = models.ProblemsAndTags
+
+    def get_queryset(self):
+        queryset = self.model.objects.filter(org_id=self.org_id)
+        items = queryset.all()
+
+        result = {}
+
+        for v in items:
+            if v.module_id in result:
+                if v.tag_name not in result[v.module_id]['tags']:
+                    result[v.module_id]['tags'][v.tag_name] = []
+                result[v.module_id]['tags'][v.tag_name].append(v.tag_value)
+                result[v.module_id]['tags'][v.tag_name].sort()
+                if result[v.module_id]['created'] < v.created:
+                    result[v.module_id]['created'] = v.created
+            else:
+                result[v.module_id] = {
+                    'course_id': v.course_id,
+                    'module_id': v.module_id,
+                    'total_submissions': v.total_submissions,
+                    'correct_submissions': v.correct_submissions,
+                    'tags': {
+                        v.tag_name: [v.tag_value]
+                    },
+                    'created': v.created
+                }
+
+        return result.values()


### PR DESCRIPTION
API endpoint to return information about orgs and connected courses/tags.

This PR is continuation of the work that was started here: https://github.com/edx/edx-analytics-pipeline/pull/323

>We use microsites and different organizations heavily in our edX
instance. We have a use case for being able to review aggregated data
across one or more courses. Our customers (colleges and universities)
want to be able to see performance across courses. With the stock edX
Analytics performance reports, it can be problematic to compare courses
with differing grade configurations. Using the Learning Outcomes report
that we created (already merged to edx master), we can compare aggregate
by Learning Outcome tags. These tags are applied to questions and are an
alternative dimension to course structure. This allows us to roll up
courses to a single learning outcome.

>The most important part of this update relates to the analytics pipeline
and api. This data view rolls up statistics across courses, and could be
utilized by edX Analytics Dashboard, or by a third party data
visualization tool.

>Our goal is to build an analytics dashboard report off of this data
view. This report would allow selecting one or more courses to view in
aggregate, and would be able to be scoped by Organization.

/cc @baldwin47