### PR TITLE
AN-7775 Generate local video data

### DIFF
--- a/analyticsdataserver/clients.py
+++ b/analyticsdataserver/clients.py
@@ -1,0 +1,56 @@
+import logging
+
+from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.exceptions import HttpClientError
+from opaque_keys.edx.keys import UsageKey
+from opaque_keys import InvalidKeyError
+
+from analyticsdataserver.utils import temp_log_level
+
+logger = logging.getLogger(__name__)
+
+
+class CourseBlocksApiClient(EdxRestApiClient):
+    """
+    This class is a sub-class of the edX Rest API Client
+    (https://github.com/edx/edx-rest-api-client).
+
+    Details about the API itself can be found at
+    https://openedx.atlassian.net/wiki/display/AN/Course+Structure+API.
+
+    Currently, this client is only used for a local-only developer script (generate_fake_course_data).
+    """
+    def __init__(self, url, access_token, timeout):
+        super(CourseBlocksApiClient, self).__init__(url, oauth_access_token=access_token, timeout=timeout)
+
+    def all_videos(self, course_id):
+        try:
+            logger.debug('Retrieving course video blocks for course_id: %s', course_id)
+            response = self.blocks.get(course_id=course_id, all_blocks=True, depth='all', block_types_filter='video')
+            logger.info("Successfully authenticated with the Course Blocks API.")
+        except HttpClientError as e:
+            if e.response.status_code == 401:
+                logger.warning("Course Blocks API failed to return video ids (%s). " +
+                               "See README for instructions on how to authenticate the API with your local LMS.",
+                               e.response.status_code)
+            elif e.response.status_code == 404:
+                logger.warning("Course Blocks API failed to return video ids (%s). " +
+                               "Does the course exist in the LMS?",
+                               e.response.status_code)
+            else:
+                logger.warning("Course Blocks API failed to return video ids (%s).", e.response.status_code)
+            return None
+
+        # Setup a terrible hack to silence mysterious flood of ImportErrors from stevedore inside edx-opaque-keys.
+        # (The UsageKey utility still works despite the import errors, so I think the errors are not important).
+        with temp_log_level('stevedore', log_level=logging.CRITICAL):
+            videos = []
+            for video in response['blocks'].values():
+                try:
+                    encoded_id = UsageKey.from_string(video['id']).html_id()
+                except InvalidKeyError:
+                    encoded_id = video['id']  # just pass through any wonky ids we don't understand
+                videos.append({'video_id': course_id + '|' + encoded_id,
+                               'video_module_id': encoded_id})
+
+        return videos

--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -56,10 +56,15 @@ CACHES = {
 ANALYTICS_DATABASE = 'analytics'
 ENABLE_ADMIN_SITE = True
 
-########## END ANALYTICS DATA API CONFIGURATION
-
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 SWAGGER_SETTINGS = {
     'api_key': 'edx'
 }
+
+# These two settings are used in generate_fake_course_data.py.
+# Replace with correct values to generate local fake video data.
+LMS_BASE_URL = 'http://localhost:8000/'  # the base URL for your running local LMS instance
+COURSE_BLOCK_API_AUTH_TOKEN = 'paste auth token here'  # see README for instructions on how to configure this value
+
+########## END ANALYTICS DATA API CONFIGURATION

--- a/analyticsdataserver/utils.py
+++ b/analyticsdataserver/utils.py
@@ -1,0 +1,20 @@
+# Put utilities that are used in managing the server or local environment here.
+# Utilities critical to application functionality should go under analytics_data_api.
+import logging
+from contextlib import contextmanager
+
+
+@contextmanager
+def temp_log_level(logger_name, log_level=logging.CRITICAL):
+    """
+    A context manager that temporarily adjusts a logger's log level.
+
+    By default, log_level is logging.CRITICAL, which will effectively silence the logger while the context
+    manager is active.
+    """
+    logger = logging.getLogger(logger_name)
+    original_log_level = logger.getEffectiveLevel()
+    logger.setLevel(log_level)  # silences all logs up to but not including this level
+    yield
+    # Return log level back to what it was.
+    logger.setLevel(original_log_level)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,3 +15,4 @@ Markdown==2.6.6    					# BSD
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.2.0
 edx-opaque-keys==0.4.0
+edx-rest-api-client==1.4.0          # Apache 2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,3 +13,4 @@ pep257==0.7.0
 pep8==1.7.0
 pylint==1.6.4
 pytz==2016.6.1
+responses==0.5.1


### PR DESCRIPTION
Adds new functionality to the `generate_fake_course_data.py` script that will generate fake video data for every video that exists in the course.

This will allow developers to test Insights functionality dealing with videos (e.g. visiting `/engagement/videos/` for a course) without having to point their local Insights server to a real or staging data API.

The authorization set-up is pretty complicated, but this is to avoid having to create a whole OAuth client in the API just for this one developer convenience. 