### PR TITLE
Add "analyticsapi" to local ALLOWED_HOSTS setting

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             '--course_id',
             action='store',
             dest='course_id',
-            default='course-v1:edX+DemoX+Demo_Courset',
+            default='course-v1:edX+DemoX+Demo_Course',
             help='Course ID for which to generate fake data',
         )
         parser.add_argument(

--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -67,4 +67,11 @@ SWAGGER_SETTINGS = {
 LMS_BASE_URL = 'http://localhost:8000/'  # the base URL for your running local LMS instance
 COURSE_BLOCK_API_AUTH_TOKEN = 'paste auth token here'  # see README for instructions on how to configure this value
 
+# In Insights, we run this API as a separate service called "analyticsapi" to run acceptance/integration tests. Docker
+# saves the service name as a host in the Insights container so it can reach the API by requesting http://analyticsapi/.
+# However, in Django 1.10.3, the HTTP_HOST header of requests started to be checked against the ALLOWED_HOSTS setting
+# even in DEBUG=True mode. Here, we add the Docker service name "analyticsapi" to the default set of local allowed
+# hosts.
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '::1', 'analyticsapi']
+
 ########## END ANALYTICS DATA API CONFIGURATION


### PR DESCRIPTION
The comment in the file should explain the issue. This is blocking the build in https://github.com/edx/edx-analytics-dashboard/pull/601 from passing.

I will have a separate change in edx-analytics-dashboard to rename the docker service from "analytics_api" to "analyticsapi" to conform to RFC 1034/1035 that does not allow underscores.

Also, unrelated to all of this, I also fixed a spelling mistake for default course-id value in generate_fake_course_data.py script.