### PR TITLE
Add --no-videos option to generate_fake_course_data command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ demo: clean requirements loaddata
 travis: clean test.requirements migrate
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
-	python manage.py generate_fake_course_data --num-weeks=1
+	python manage.py generate_fake_course_data --num-weeks=1 --no-videos

--- a/analyticsdataserver/clients.py
+++ b/analyticsdataserver/clients.py
@@ -1,5 +1,7 @@
 import logging
 
+from requests.exceptions import RequestException
+
 from edx_rest_api_client.client import EdxRestApiClient
 from edx_rest_api_client.exceptions import HttpClientError
 from opaque_keys.edx.keys import UsageKey
@@ -39,6 +41,9 @@ class CourseBlocksApiClient(EdxRestApiClient):
                                e.response.status_code)
             else:
                 logger.warning("Course Blocks API failed to return video ids (%s).", e.response.status_code)
+            return None
+        except RequestException as e:
+            logger.warning("Course Blocks API request failed. Is the LMS running?: " + str(e))
             return None
 
         # Setup a terrible hack to silence mysterious flood of ImportErrors from stevedore inside edx-opaque-keys.


### PR DESCRIPTION
Travis calls the generate_fake_course_data command, but the LMS is not hosted at localhost:8000, so it was throwing a ConnectionError and breaking the build. As far as I know, fake video data is not needed in the tests so I added an option to turn it off.

I also made the script more resilient and will fallback to fake ids on a ConnectionError in the future.