### PR TITLE
Use old-style course ID for fake data in Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ demo: clean requirements loaddata
 travis: clean test.requirements migrate
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
-	python manage.py generate_fake_course_data --num-weeks=1 --no-videos
+	python manage.py generate_fake_course_data --num-weeks=1 --no-videos --course-id "edX/DemoX/Demo_Course"

--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             help='Number of weeks worth of data to generate.',
         )
         parser.add_argument(
-            '--course_id',
+            '--course-id',
             action='store',
             dest='course_id',
             default='course-v1:edX+DemoX+Demo_Course',


### PR DESCRIPTION
Also change option name course_id to course-id to consistently use hyphens in
option parameters.