### PR TITLE
AN-8236 Collapse "Upcoming" and "Starting soon" availability

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -167,7 +167,7 @@ class Command(BaseCommand):
                 course_id=course_id, catalog_course_title='Demo Course', catalog_course='Demo_Course',
                 start_time=timezone.now() - datetime.timedelta(weeks=6),
                 end_time=timezone.now() + datetime.timedelta(weeks=10),
-                pacing_type='self_paced', availability='Current', enrollment_mode=mode, count=count,
+                pacing_type='self_paced', availability='Starting Soon', enrollment_mode=mode, count=count,
                 cumulative_count=cumulative_count, count_change_7_days=random.randint(-50, 50))
 
         progress.update(1)

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -117,6 +117,10 @@ class CourseSummariesView(generics.ListAPIView):
             for count_key in count_fields:
                 prof_mode[count_key] = prof_mode.get(count_key, 0) + prof_no_id_mode.pop(count_key, 0)
 
+            # AN-8236 replace "Starting Soon" to "Upcoming" availability to collapse the two into one value
+            if item['availability'] == 'Starting Soon':
+                item['availability'] = 'Upcoming'
+
             formatted_data.append(item)
 
         return formatted_data


### PR DESCRIPTION
Insights needs to treat "Starting Soon" the same as "Upcoming".

"Starting Soon" is still stored in the database, but it is collapsed into
the "Upcoming" category in the API view response.