### PR TITLE
Support multi-leaf tagging

### DIFF
--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -668,6 +668,9 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
           tag_name='difficulty', tag_value=tags['difficulty'][0],
           total_submissions=11, correct_submissions=4, created=created)
         G(models.ProblemsAndTags, course_id=course_id, module_id=module_id,
+          tag_name='difficulty', tag_value=tags['difficulty'][1],
+          total_submissions=11, correct_submissions=4, created=created)
+        G(models.ProblemsAndTags, course_id=course_id, module_id=module_id,
           tag_name='learning_outcome', tag_value=tags['learning_outcome'][1],
           total_submissions=11, correct_submissions=4, created=alt_created)
         G(models.ProblemsAndTags, course_id=course_id, module_id=alt_module_id,
@@ -680,8 +683,8 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
                 'total_submissions': 11,
                 'correct_submissions': 4,
                 'tags': {
-                    u'difficulty': u'Easy',
-                    u'learning_outcome': u'Learned a few things',
+                    u'difficulty': [u'Easy', u'Medium'],
+                    u'learning_outcome': [u'Learned a few things'],
                 },
                 'created': alt_created.strftime(settings.DATETIME_FORMAT)
             },
@@ -690,7 +693,7 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
                 'total_submissions': 4,
                 'correct_submissions': 0,
                 'tags': {
-                    u'learning_outcome': u'Learned everything',
+                    u'learning_outcome': [u'Learned everything'],
                 },
                 'created': created.strftime(settings.DATETIME_FORMAT)
             }

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -714,7 +714,7 @@ class ProblemsAndTagsListView(BaseCourseView):
             * module_id: The ID of the problem.
             * total_submissions: Total number of submissions.
             * correct_submissions: Total number of *correct* submissions.
-            * tags: Dictionary that contains pairs "tag key: tag value".
+            * tags: Dictionary that contains pairs "tag key: [tag value 1, tag value 2, ..., tag value N]".
     """
     serializer_class = serializers.ProblemsAndTagsSerializer
     allow_empty = False
@@ -729,7 +729,10 @@ class ProblemsAndTagsListView(BaseCourseView):
 
         for v in items:
             if v.module_id in result:
-                result[v.module_id]['tags'][v.tag_name] = v.tag_value
+                if v.tag_name not in result[v.module_id]['tags']:
+                    result[v.module_id]['tags'][v.tag_name] = []
+                result[v.module_id]['tags'][v.tag_name].append(v.tag_value)
+                result[v.module_id]['tags'][v.tag_name].sort()
                 if result[v.module_id]['created'] < v.created:
                     result[v.module_id]['created'] = v.created
             else:
@@ -738,7 +741,7 @@ class ProblemsAndTagsListView(BaseCourseView):
                     'total_submissions': v.total_submissions,
                     'correct_submissions': v.correct_submissions,
                     'tags': {
-                        v.tag_name: v.tag_value
+                        v.tag_name: [v.tag_value]
                     },
                     'created': v.created
                 }


### PR DESCRIPTION
It is a little fix that allow to return multiple tag values for each tag through the `/api/v0/courses/foo-bar/problems_and_tags` API.
This task related to https://github.com/edx/edx-platform/pull/13899 and https://github.com/edx/edx-analytics-pipeline/pull/312

@mulby could you please take a look.