### PR TITLE
Make ElasticSearch aggregate search results size configurable

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -407,11 +407,14 @@ class RosterEntry(DocType):
             }
         }
         """
+        # Use the configured default page size to set the number of aggregate search results.
+        page_size = getattr(settings, 'AGGREGATE_PAGE_SIZE', 10)
+
         search = cls.search()
         search.query = Q('bool', must=[Q('term', course_id=course_id)])
-        search.aggs.bucket('enrollment_modes', 'terms', field='enrollment_mode')
-        search.aggs.bucket('segments', 'terms', field='segments')
-        search.aggs.bucket('cohorts', 'terms', field='cohort')
+        search.aggs.bucket('enrollment_modes', 'terms', field='enrollment_mode', size=page_size)
+        search.aggs.bucket('segments', 'terms', field='segments', size=page_size)
+        search.aggs.bucket('cohorts', 'terms', field='cohort', size=page_size)
         response = search.execute()
         # Build up the map of aggregation name to count
         aggregations = {

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -310,6 +310,7 @@ ENABLED_REPORT_IDENTIFIERS = ('problem_response',)
 # Warning: using 0 or None for these can alter the structure of the REST response.
 DEFAULT_PAGE_SIZE = 25
 MAX_PAGE_SIZE = 100
+AGGREGATE_PAGE_SIZE = 10
 
 ########## END ANALYTICS DATA API CONFIGURATION
 


### PR DESCRIPTION
Uses a new `settings.AGGREGATE_PAGE_SIZE` as the Elasticsearch aggregate search results size.  Default value is `10`, which matches the [elasticsearch_dsl default](https://github.com/elastic/elasticsearch-dsl-py/blob/1a9092429ac582c0cf33f8d6287a20266be063cd/elasticsearch_dsl/search.py#L261).

Please see also https://github.com/edx/configuration/pull/3738

**JIRA tickets**: [OSPR-1695](https://openedx.atlassian.net/browse/OSPR-1695)

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: insights.edx.org and insights.edge.edx.org

**Merge deadline**: 31 Mar 2017 if possible.  We'd like to deploy this change when upgrading our clients to Ficus.

**Testing instructions**:

1. Create an [analytics devstack](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/analytics/install_analytics.html).
1. In Studio, [Enable Cohorts](http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/cohorts/cohort_config.html) for your course, and create 2 or more cohorts.
1. Run the test ElasticSearch service (alternately use a separate docker service):

    ```
    analytics_api@vagrant:~/analytics_api$ make test.install_elasticsearch
    analytics_api@vagrant:~/analytics_api$ make test.run_elasticsearch
    ```
1. [Run these analytics tasks](https://openedx.atlassian.net/wiki/display/OpenOPS/edX+Analytics+Installation):

    ```
    sudo su hadoop
    cd /edx/app/analytics_pipeline/
    source venvs/analytics_pipeline/bin/activate
    cd analytics_pipeline

    # Run ImportEnrollmentsIntoMysql to load user profile data -?
    TOMORROW=`date --date="tomorrow" +%Y-%m-%d`
    launch-task ImportEnrollmentsIntoMysql --interval 2017-01-01-$TOMORROW --local-scheduler --n-reduce-tasks 2 --remote-log-level DEBUG

    # Run learner engagement task
    TODAY=`date +%Y-%m-%d`
    launch-task ModuleEngagagementWorkflowTask --date $TODAY --local-scheduler --n-reduce-tasks 2 --remote-log-level DEBUG
    ```
1. Using this PR's branch, set the analytics_api setting `AGGREGATE_PAGE_SIZE` to 1 (in `/edx/etc/analytics_api.yml`), and run the Analytics API.
1. Enable Learner Analytics using the [`display_learner_analytics` waffle flag](https://github.com/edx/edx-analytics-dashboard#feature-gating).
1. Run Insights.
1. Note that only 1 cohort appears in the Learners > Cohort Groups drop down for your course.
1. Set the analytics_api setting `AGGREGATE_PAGE_SIZE` to 2, and restart the Analytics API.
1. Note that you can now see 2 cohorts in the Learners > Cohort Groups drop down for your course.

**Reviewers**
- [x] @bdero
- [ ] @edx/analytics reviewer TBD