### PR TITLE
Fix Monday Insights build failures by generating 2 weeks of data for Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ demo: clean requirements loaddata
 travis: clean test.requirements migrate
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
-	python manage.py generate_fake_course_data --num-weeks=1 --no-videos --course-id "edX/DemoX/Demo_Course"
+	python manage.py generate_fake_course_data --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"


### PR DESCRIPTION
We picked 1 week of data to generate for Travis because it is the fastest, but on when run on Mondays this causes there to be only one course activity row (1 week) to be returned by the API. Because of [this line in Insights](https://github.com/edx/edx-analytics-dashboard/blob/master/analytics_dashboard/courses/presenters/engagement.py#L53), whenever there is only one row of course activity, we create another blank one so that the chart has more than one item in the axis (it looks bad with only one). However, the tests do not anticipate that; they expect there only to be one row because that is what is returned by the API.

The easiest fix for this turns out to be just generating another week of data for Travis. Then, 2 rows are returned by the API and we don't run into the issue with the extra blank row Insights adds.

I tested the failing Insights test locally before and after this change and it seems to fix the failure.