### PR TITLE
AN-8581 Add exception argument to handler404 function signature

### DIFF
--- a/analyticsdataserver/views.py
+++ b/analyticsdataserver/views.py
@@ -12,7 +12,7 @@ def handle_internal_server_error(_request):
     return _handle_error(500)
 
 
-def handle_missing_resource_error(_request, _):
+def handle_missing_resource_error(_request, exception=None):  # pylint: disable=unused-argument
     """Notify the client that the requested resource could not be found."""
     return _handle_error(404)
 

--- a/analyticsdataserver/views.py
+++ b/analyticsdataserver/views.py
@@ -12,7 +12,7 @@ def handle_internal_server_error(_request):
     return _handle_error(500)
 
 
-def handle_missing_resource_error(_request, exception):
+def handle_missing_resource_error(_request, _):
     """Notify the client that the requested resource could not be found."""
     return _handle_error(404)
 

--- a/analyticsdataserver/views.py
+++ b/analyticsdataserver/views.py
@@ -12,7 +12,7 @@ def handle_internal_server_error(_request):
     return _handle_error(500)
 
 
-def handle_missing_resource_error(_request):
+def handle_missing_resource_error(_request, exception):
     """Notify the client that the requested resource could not be found."""
     return _handle_error(404)
 


### PR DESCRIPTION
[Django 1.9 changed the function signature of the handler404 function](https://docs.djangoproject.com/en/1.9/ref/views/#django.views.defaults.page_not_found) to accept an exception argument. Our custom handler had the wrong number of arguments. This problem is only apparent with the newrelic wsgi wrapper which was causing an exception on every 404.