### PR TITLE
AN-8555 Add programs endpoint

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -115,7 +115,8 @@ class Command(BaseCommand):
                       models.CourseEnrollmentByEducation,
                       models.CourseEnrollmentByBirthYear,
                       models.CourseEnrollmentByCountry,
-                      models.CourseMetaSummaryEnrollment]:
+                      models.CourseMetaSummaryEnrollment,
+                      models.CourseProgramMetadata]:
             model.objects.all().delete()
 
         logger.info("Deleted all daily course enrollment data.")
@@ -169,6 +170,9 @@ class Command(BaseCommand):
                 end_time=timezone.now() + datetime.timedelta(weeks=10),
                 pacing_type='self_paced', availability='Starting Soon', enrollment_mode=mode, count=count,
                 cumulative_count=cumulative_count, count_change_7_days=random.randint(-50, 50))
+
+        models.CourseProgramMetadata.objects.create(course_id=course_id, program_id='Demo_Program',
+                                                    program_type='Demo', program_title='Demo Program')
 
         progress.update(1)
         progress.close()

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -85,6 +85,17 @@ class CourseMetaSummaryEnrollment(BaseCourseModel):
         unique_together = [('course_id', 'enrollment_mode',)]
 
 
+class CourseProgramMetadata(BaseCourseModel):
+    program_id = models.CharField(db_index=True, max_length=255)
+    program_type = models.CharField(db_index=True, max_length=255)
+    program_title = models.CharField(max_length=255)
+
+    class Meta(BaseCourseModel.Meta):
+        db_table = 'course_program_metadata'
+        ordering = ('course_id',)
+        unique_together = [('course_id', 'program_id',)]
+
+
 class CourseEnrollmentByBirthYear(BaseCourseEnrollment):
     birth_year = models.IntegerField(null=False)
 

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -555,3 +555,19 @@ class CourseMetaSummaryEnrollmentSerializer(ModelSerializerWithCreatedField, Dyn
         model = models.CourseMetaSummaryEnrollment
         # start_date and end_date used instead of start_time and end_time
         exclude = ('id', 'start_time', 'end_time', 'enrollment_mode')
+
+
+class CourseProgramMetadataSerializer(ModelSerializerWithCreatedField, DynamicFieldsModelSerializer):
+    """
+    Serializer for course and the programs it is under.
+    """
+    course_id = serializers.CharField()
+    program_id = serializers.CharField()
+    program_type = serializers.CharField()
+    program_title = serializers.CharField()
+
+    class Meta(object):
+        model = models.CourseProgramMetadata
+        # excluding course-related fields because the serialized output will be embedded in a course object
+        # with thsoe fields already defined
+        exclude = ('id', 'created')

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -580,17 +580,16 @@ class CourseProgramMetadataSerializer(ModelSerializerWithCreatedField, DynamicFi
     """
     Serializer for course and the programs it is under.
     """
-    course_id = serializers.CharField()
     program_id = serializers.CharField()
     program_type = serializers.CharField()
     program_title = serializers.CharField()
-    courses = serializers.SerializerMethodField()
+    course_ids = serializers.SerializerMethodField()
 
-    def get_courses(self, obj):
-        return obj.get('courses', None)
+    def get_course_ids(self, obj):
+        return obj.get('course_ids', None)
 
     class Meta(object):
         model = models.CourseProgramMetadata
         # excluding course-related fields because the serialized output will be embedded in a course object
-        # with thsoe fields already defined
-        exclude = ('id', 'created')
+        # with those fields already defined
+        exclude = ('id', 'created', 'course_id')

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -511,15 +511,23 @@ class CourseLearnerMetadataSerializer(serializers.Serializer):
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
     """
-    A ModelSerializer that takes an additional `fields` argument that controls which
+    A ModelSerializer that takes additional `fields` and/or `exclude` keyword arguments that control which
     fields should be displayed.
 
     Blatantly taken from http://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
+
+    If a field name is specified in both `fields` and `exclude`, then the exclude option takes precedence and the field
+    will not be included in the serialized result.
+
+    Keyword Arguments:
+        fields  -- list of field names on the model to include in the serialized result
+        exclude -- list of field names on the model to exclude in the serialized result
     """
 
     def __init__(self, *args, **kwargs):
         # Don't pass the 'fields' arg up to the superclass
         fields = kwargs.pop('fields', None)
+        exclude = kwargs.pop('exclude', None)
 
         # Instantiate the superclass normally
         super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
@@ -529,6 +537,13 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
             allowed = set(fields)
             existing = set(self.fields.keys())
             for field_name in existing - allowed:
+                self.fields.pop(field_name)
+
+        if exclude is not None:
+            # Drop any fields that are specified in the `exclude` argument.
+            disallowed = set(exclude)
+            existing = set(self.fields.keys())
+            for field_name in existing & disallowed:  # intersection
                 self.fields.pop(field_name)
 
 
@@ -547,9 +562,13 @@ class CourseMetaSummaryEnrollmentSerializer(ModelSerializerWithCreatedField, Dyn
     cumulative_count = serializers.IntegerField(default=0)
     count_change_7_days = serializers.IntegerField(default=0)
     enrollment_modes = serializers.SerializerMethodField()
+    programs = serializers.SerializerMethodField()
 
     def get_enrollment_modes(self, obj):
         return obj.get('enrollment_modes', None)
+
+    def get_programs(self, obj):
+        return obj.get('programs', None)
 
     class Meta(object):
         model = models.CourseMetaSummaryEnrollment

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -584,6 +584,10 @@ class CourseProgramMetadataSerializer(ModelSerializerWithCreatedField, DynamicFi
     program_id = serializers.CharField()
     program_type = serializers.CharField()
     program_title = serializers.CharField()
+    courses = serializers.SerializerMethodField()
+
+    def get_courses(self, obj):
+        return obj.get('courses', None)
 
     class Meta(object):
         model = models.CourseProgramMetadata

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -1,0 +1,27 @@
+from datetime import date
+from django.test import TestCase
+from django_dynamic_fixture import G
+
+from analytics_data_api.v0 import models as api_models, serializers as api_serializers
+
+
+class TestSerializer(api_serializers.CourseEnrollmentDailySerializer, api_serializers.DynamicFieldsModelSerializer):
+    pass
+
+
+class DynamicFieldsModelSerializerTests(TestCase):
+    def test_fields(self):
+        now = date.today()
+        instance = G(api_models.CourseEnrollmentDaily, course_id='1', count=1, date=now)
+        serialized = TestSerializer(instance)
+        self.assertListEqual(serialized.data.keys(), ['course_id', 'date', 'count', 'created'])
+
+        instance = G(api_models.CourseEnrollmentDaily, course_id='2', count=1, date=now)
+        serialized = TestSerializer(instance, fields=('course_id',))
+        self.assertListEqual(serialized.data.keys(), ['course_id'])
+
+    def test_exclude(self):
+        now = date.today()
+        instance = G(api_models.CourseEnrollmentDaily, course_id='3', count=1, date=now)
+        serialized = TestSerializer(instance, exclude=('course_id',))
+        self.assertListEqual(serialized.data.keys(), ['date', 'count', 'created'])

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -15,6 +15,12 @@ class CourseSamples(object):
         'ccx-v1:edx+1.005x-CCX+rerun+ccx@15'
     ]
 
+    program_ids = [
+        '482dee71-e4b9-4b42-a47b-3e16bb69e8f2',
+        '71c14f59-35d5-41f2-a017-e108d2d9f127',
+        'cfc6b5ee-6aa1-4c82-8421-20418c492618'
+    ]
+
 
 class VerifyCourseIdMixin(object):
 

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -100,16 +100,16 @@ class APIListViewTestMixin(object):
     default_ids = []
     always_exclude = ['created']
 
-    def path(self, ids=None, fields=None, exclude=None):
+    def path(self, ids=None, fields=None, exclude=None, **kwargs):
         query_params = {}
-        for query_arg, data in zip(['ids', 'fields', 'exclude'], [ids, fields, exclude]):
+        for query_arg, data in zip(['ids', 'fields', 'exclude'], [ids, fields, exclude]) + kwargs.items():
             if data:
                 query_params[query_arg] = ','.join(data)
         query_string = '?{}'.format(urlencode(query_params))
         return '/api/v0/{}/{}'.format(self.list_name, query_string)
 
     def create_model(self, model_id, **kwargs):
-        G(self.model, id=model_id, **kwargs)
+        pass  # implement in subclass
 
     def generate_data(self, ids=None, **kwargs):
         """Generate list data"""

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -181,4 +181,6 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
         expected_summaries.extend(self.all_expected_summaries(course_ids=['foo/bar/baz'],
                                                               availability='Upcoming'))
 
-        self.assertItemsEqual(response.data, expected_summaries)
+        expected = sorted(expected_summaries, key=lambda x: x['course_id'])
+        actual = sorted(response.data, key=lambda x: x['course_id'])
+        self.assertListEqual(actual, expected)

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -27,9 +27,9 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     def tearDown(self):
         self.model.objects.all().delete()
 
-    def path(self, course_ids=None, fields=None):
+    def path(self, course_ids=None, fields=None, exclude=None):
         query_params = {}
-        for query_arg, data in zip(['course_ids', 'fields'], [course_ids, fields]):
+        for query_arg, data in zip(['course_ids', 'fields', 'exclude'], [course_ids, fields, exclude]):
             if data:
                 query_params[query_arg] = ','.join(data)
         query_string = '?{}'.format(urlencode(query_params))
@@ -113,14 +113,14 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     )
     def test_all_courses(self, course_ids):
         self.generate_data()
-        response = self.authenticated_get(self.path(course_ids=course_ids))
+        response = self.authenticated_get(self.path(course_ids=course_ids, exclude=('programs',)))
         self.assertEquals(response.status_code, 200)
         self.assertItemsEqual(response.data, self.all_expected_summaries())
 
     @ddt.data(*CourseSamples.course_ids)
     def test_one_course(self, course_id):
         self.generate_data()
-        response = self.authenticated_get(self.path(course_ids=[course_id]))
+        response = self.authenticated_get(self.path(course_ids=[course_id], exclude=('programs',)))
         self.assertEquals(response.status_code, 200)
         self.assertItemsEqual(response.data, [self.expected_summary(course_id)])
 
@@ -147,7 +147,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     )
     def test_empty_modes(self, modes):
         self.generate_data(modes=modes)
-        response = self.authenticated_get(self.path())
+        response = self.authenticated_get(self.path(exclude=('programs',)))
         self.assertEquals(response.status_code, 200)
         self.assertItemsEqual(response.data, self.all_expected_summaries(modes))
 
@@ -171,7 +171,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     def test_collapse_upcoming(self):
         self.generate_data(availability='Starting Soon')
         self.generate_data(course_ids=['foo/bar/baz'], availability='Upcoming')
-        response = self.authenticated_get(self.path())
+        response = self.authenticated_get(self.path(exclude=('programs',)))
         self.assertEquals(response.status_code, 200)
 
         expected_summaries = self.all_expected_summaries(availability='Upcoming')

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
 import datetime
-from urllib import urlencode
 
 import ddt
 from django_dynamic_fixture import G
@@ -10,15 +8,19 @@ from django.conf import settings
 
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin
+from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin, APIListViewTestMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 
 @ddt.ddt
-class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
+class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseMetaSummaryEnrollment
+    model_id = 'course_id'
     serializer = serializers.CourseMetaSummaryEnrollmentSerializer
     expected_summaries = []
+    list_name = 'course_summaries'
+    default_ids = CourseSamples.course_ids
+    always_exclude = ['created', 'programs']
 
     def setUp(self):
         super(CourseSummariesViewTests, self).setUp()
@@ -28,32 +30,25 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     def tearDown(self):
         self.model.objects.all().delete()
 
-    def path(self, course_ids=None, fields=None, exclude=None):
-        query_params = {}
-        for query_arg, data in zip(['ids', 'fields', 'exclude'], [course_ids, fields, exclude]):
-            if data:
-                query_params[query_arg] = ','.join(data)
-        query_string = '?{}'.format(urlencode(query_params))
-        return '/api/v0/course_summaries/{}'.format(query_string)
+    def create_model(self, model_id, **kwargs):
+        for mode in kwargs['modes']:
+            G(self.model, course_id=model_id, catalog_course_title='Title', catalog_course='Catalog',
+              start_time=datetime.datetime(2016, 10, 11, tzinfo=pytz.utc),
+              end_time=datetime.datetime(2016, 12, 18, tzinfo=pytz.utc),
+              pacing_type='instructor', availability=kwargs['availability'], enrollment_mode=mode,
+              count=5, cumulative_count=10, count_change_7_days=1, create=self.now,)
 
-    def generate_data(self, course_ids=None, modes=None, availability='Current'):
-        """Generate course summary data for """
-        if course_ids is None:
-            course_ids = CourseSamples.course_ids
-
+    def generate_data(self, ids=None, modes=None, availability='Current', **kwargs):
+        """Generate course summary data"""
         if modes is None:
             modes = enrollment_modes.ALL
 
-        for course_id in course_ids:
-            for mode in modes:
-                G(self.model, course_id=course_id, catalog_course_title='Title', catalog_course='Catalog',
-                  start_time=datetime.datetime(2016, 10, 11, tzinfo=pytz.utc),
-                  end_time=datetime.datetime(2016, 12, 18, tzinfo=pytz.utc),
-                  pacing_type='instructor', availability=availability, enrollment_mode=mode,
-                  count=5, cumulative_count=10, count_change_7_days=1, create=self.now,)
+        super(CourseSummariesViewTests, self).generate_data(ids=ids, modes=modes, availability=availability, **kwargs)
 
-    def expected_summary(self, course_id, modes=None, availability='Current'):
+    def expected_result(self, item_id, modes=None, availability='Current'):  # pylint: disable=arguments-differ
         """Expected summary information for a course and modes to populate with data."""
+        summary = super(CourseSummariesViewTests, self).expected_result(item_id)
+
         if modes is None:
             modes = enrollment_modes.ALL
 
@@ -61,9 +56,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
         count_factor = 5
         cumulative_count_factor = 10
         count_change_factor = 1
-        summary = OrderedDict([
-            ('created', self.now.strftime(settings.DATETIME_FORMAT)),
-            ('course_id', course_id),
+        summary.update([
             ('catalog_course_title', 'Title'),
             ('catalog_course', 'Catalog'),
             ('start_date', datetime.datetime(2016, 10, 11, tzinfo=pytz.utc).strftime(settings.DATETIME_FORMAT)),
@@ -98,14 +91,12 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
         })
         return summary
 
-    def all_expected_summaries(self, modes=None, course_ids=None, availability='Current'):
-        if course_ids is None:
-            course_ids = CourseSamples.course_ids
-
+    def all_expected_results(self, ids=None, modes=None, availability='Current'):  # pylint: disable=arguments-differ
         if modes is None:
             modes = enrollment_modes.ALL
 
-        return [self.expected_summary(course_id, modes, availability) for course_id in course_ids]
+        return super(CourseSummariesViewTests, self).all_expected_results(ids=ids, modes=modes,
+                                                                          availability=availability)
 
     @ddt.data(
         None,
@@ -113,36 +104,18 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
         ['not/real/course'].extend(CourseSamples.course_ids),
     )
     def test_all_courses(self, course_ids):
-        self.generate_data()
-        response = self.authenticated_get(self.path(course_ids=course_ids, exclude=('programs',)))
-        self.assertEquals(response.status_code, 200)
-        expected = sorted(self.all_expected_summaries(course_ids=course_ids), key=lambda x: x['course_id'])
-        actual = sorted(response.data, key=lambda x: x['course_id'])
-        self.assertListEqual(actual, expected)
+        self._test_all_items(course_ids)
 
     @ddt.data(*CourseSamples.course_ids)
     def test_one_course(self, course_id):
-        self.generate_data()
-        response = self.authenticated_get(self.path(course_ids=[course_id], exclude=('programs',)))
-        self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, [self.expected_summary(course_id)])
+        self._test_one_item(course_id)
 
     @ddt.data(
         ['availability'],
         ['enrollment_mode', 'course_id'],
     )
     def test_fields(self, fields):
-        self.generate_data()
-        response = self.authenticated_get(self.path(fields=fields))
-        self.assertEquals(response.status_code, 200)
-
-        # remove fields not requested from expected results
-        expected_summaries = self.all_expected_summaries()
-        for expected_summary in expected_summaries:
-            for field_to_remove in set(expected_summary.keys()) - set(fields):
-                expected_summary.pop(field_to_remove)
-
-        self.assertItemsEqual(response.data, expected_summaries)
+        self._test_fields(fields)
 
     @ddt.data(
         [enrollment_modes.VERIFIED],
@@ -150,37 +123,26 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     )
     def test_empty_modes(self, modes):
         self.generate_data(modes=modes)
-        response = self.authenticated_get(self.path(exclude=('programs',)))
+        response = self.authenticated_get(self.path(exclude=self.always_exclude))
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_summaries(modes))
-
-    def test_no_summaries(self):
-        response = self.authenticated_get(self.path())
-        self.assertEquals(response.status_code, 404)
-
-    def test_no_matching_courses(self):
-        self.generate_data()
-        response = self.authenticated_get(self.path(course_ids=['no/course/found']))
-        self.assertEquals(response.status_code, 404)
+        self.assertItemsEqual(response.data, self.all_expected_results(modes=modes))
 
     @ddt.data(
         ['malformed-course-id'],
         [CourseSamples.course_ids[0], 'malformed-course-id'],
     )
     def test_bad_course_id(self, course_ids):
-        response = self.authenticated_get(self.path(course_ids=course_ids))
+        response = self.authenticated_get(self.path(ids=course_ids))
         self.verify_bad_course_id(response)
 
     def test_collapse_upcoming(self):
         self.generate_data(availability='Starting Soon')
-        self.generate_data(course_ids=['foo/bar/baz'], availability='Upcoming')
-        response = self.authenticated_get(self.path(exclude=('programs',)))
+        self.generate_data(ids=['foo/bar/baz'], availability='Upcoming')
+        response = self.authenticated_get(self.path(exclude=self.always_exclude))
         self.assertEquals(response.status_code, 200)
 
-        expected_summaries = self.all_expected_summaries(availability='Upcoming')
-        expected_summaries.extend(self.all_expected_summaries(course_ids=['foo/bar/baz'],
-                                                              availability='Upcoming'))
+        expected_summaries = self.all_expected_results(availability='Upcoming')
+        expected_summaries.extend(self.all_expected_results(ids=['foo/bar/baz'],
+                                                            availability='Upcoming'))
 
-        expected = sorted(expected_summaries, key=lambda x: x['course_id'])
-        actual = sorted(response.data, key=lambda x: x['course_id'])
-        self.assertListEqual(actual, expected)
+        self.assertItemsEqual(response.data, expected_summaries)

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -34,7 +34,7 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
         program.update([
             ('program_type', 'Demo'),
             ('program_title', 'Test'),
-            ('courses', [CourseSamples.course_ids[0]])
+            ('course_ids', [self.course_id])
         ])
         return program
 

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -1,0 +1,101 @@
+import datetime
+from collections import OrderedDict
+from urllib import urlencode
+
+import ddt
+from django_dynamic_fixture import G
+
+from analytics_data_api.v0 import models, serializers
+from analytics_data_api.v0.tests.views import CourseSamples
+from analyticsdataserver.tests import TestCaseWithAuthentication
+
+
+@ddt.ddt
+class ProgramsViewTests(TestCaseWithAuthentication):
+    model = models.CourseProgramMetadata
+    serializer = serializers.CourseProgramMetadataSerializer
+    expected_programs = []
+
+    def setUp(self):
+        super(ProgramsViewTests, self).setUp()
+        self.now = datetime.datetime.utcnow()
+        self.maxDiff = None
+        self.course_id = CourseSamples.course_ids[0]
+
+    def tearDown(self):
+        self.model.objects.all().delete()
+
+    def path(self, program_ids=None, fields=None, exclude=None):
+        query_params = {}
+        for query_arg, data in zip(['program_ids', 'fields', 'exclude'], [program_ids, fields, exclude]):
+            if data:
+                query_params[query_arg] = ','.join(data)
+        query_string = '?{}'.format(urlencode(query_params))
+        return '/api/v0/programs/{}'.format(query_string)
+
+    def generate_data(self, program_ids=None):
+        """Generate course program data"""
+        if program_ids is None:
+            program_ids = CourseSamples.program_ids
+
+        for program_id in program_ids:
+            G(self.model, course_id=self.course_id, program_id=program_id, program_type='Demo', program_title='Test')
+
+    def expected_program(self, program_id):
+        """Expected program metadata to populate with data."""
+        program = OrderedDict([
+            ('program_id', program_id),
+            ('program_type', 'Demo'),
+            ('program_title', 'Test'),
+        ])
+        return program
+
+    def all_expected_programs(self, program_ids=None):
+        if program_ids is None:
+            program_ids = CourseSamples.program_ids
+
+        return [self.expected_program(program_id) for program_id in program_ids]
+
+    @ddt.data(
+        None,
+        CourseSamples.program_ids,
+        ['not-real-program'].extend(CourseSamples.program_ids),
+    )
+    def test_all_programs(self, program_ids):
+        self.generate_data()
+        response = self.authenticated_get(self.path(program_ids=program_ids, exclude=('created',)))
+        self.assertEquals(response.status_code, 200)
+        self.assertItemsEqual(response.data, self.all_expected_programs())
+
+    @ddt.data(*CourseSamples.program_ids)
+    def test_one_course(self, program_id):
+        self.generate_data()
+        response = self.authenticated_get(self.path(program_ids=[program_id], exclude=('created',)))
+        self.assertEquals(response.status_code, 200)
+        self.assertItemsEqual(response.data, [self.expected_program(program_id)])
+
+    @ddt.data(
+        ['program_id'],
+        ['program_type', 'program_title'],
+    )
+    def test_fields(self, fields):
+        self.generate_data()
+        response = self.authenticated_get(self.path(fields=fields))
+        self.assertEquals(response.status_code, 200)
+
+        # remove fields not requested from expected results
+        expected_programs = self.all_expected_programs()
+        for expected_program in expected_programs:
+            for field_to_remove in set(expected_program.keys()) - set(fields):
+                expected_program.pop(field_to_remove)
+
+        self.assertListEqual(response.data, expected_programs)
+
+    def test_no_programs(self):
+        response = self.authenticated_get(self.path())
+        self.assertEquals(response.status_code, 404)
+
+    def test_no_matching_courses(self):
+        self.generate_data()
+        response = self.authenticated_get(self.path(program_ids=['no-program-found']))
+        self.assertEquals(response.status_code, 404)

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -27,7 +27,7 @@ class ProgramsViewTests(TestCaseWithAuthentication):
 
     def path(self, program_ids=None, fields=None, exclude=None):
         query_params = {}
-        for query_arg, data in zip(['program_ids', 'fields', 'exclude'], [program_ids, fields, exclude]):
+        for query_arg, data in zip(['ids', 'fields', 'exclude'], [program_ids, fields, exclude]):
             if data:
                 query_params[query_arg] = ','.join(data)
         query_string = '?{}'.format(urlencode(query_params))
@@ -65,7 +65,9 @@ class ProgramsViewTests(TestCaseWithAuthentication):
         self.generate_data()
         response = self.authenticated_get(self.path(program_ids=program_ids, exclude=('created',)))
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_programs())
+        expected = sorted(self.all_expected_programs(program_ids=program_ids), key=lambda x: x['program_id'])
+        actual = sorted(response.data, key=lambda x: x['program_id'])
+        self.assertListEqual(actual, expected)
 
     @ddt.data(*CourseSamples.program_ids)
     def test_one_course(self, program_id):

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -1,20 +1,20 @@
 import datetime
-from collections import OrderedDict
-from urllib import urlencode
-
 import ddt
 from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import CourseSamples
+from analytics_data_api.v0.tests.views import CourseSamples, APIListViewTestMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 
 @ddt.ddt
-class ProgramsViewTests(TestCaseWithAuthentication):
+class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseProgramMetadata
+    model_id = 'program_id'
     serializer = serializers.CourseProgramMetadataSerializer
     expected_programs = []
+    list_name = 'programs'
+    default_ids = CourseSamples.program_ids
 
     def setUp(self):
         super(ProgramsViewTests, self).setUp()
@@ -25,36 +25,17 @@ class ProgramsViewTests(TestCaseWithAuthentication):
     def tearDown(self):
         self.model.objects.all().delete()
 
-    def path(self, program_ids=None, fields=None, exclude=None):
-        query_params = {}
-        for query_arg, data in zip(['ids', 'fields', 'exclude'], [program_ids, fields, exclude]):
-            if data:
-                query_params[query_arg] = ','.join(data)
-        query_string = '?{}'.format(urlencode(query_params))
-        return '/api/v0/programs/{}'.format(query_string)
+    def create_model(self, model_id):
+        G(self.model, course_id=self.course_id, program_id=model_id, program_type='Demo', program_title='Test')
 
-    def generate_data(self, program_ids=None):
-        """Generate course program data"""
-        if program_ids is None:
-            program_ids = CourseSamples.program_ids
-
-        for program_id in program_ids:
-            G(self.model, course_id=self.course_id, program_id=program_id, program_type='Demo', program_title='Test')
-
-    def expected_program(self, program_id):
+    def expected_result(self, item_id):
         """Expected program metadata to populate with data."""
-        program = OrderedDict([
-            ('program_id', program_id),
+        program = super(ProgramsViewTests, self).expected_result(item_id)
+        program.update([
             ('program_type', 'Demo'),
             ('program_title', 'Test'),
         ])
         return program
-
-    def all_expected_programs(self, program_ids=None):
-        if program_ids is None:
-            program_ids = CourseSamples.program_ids
-
-        return [self.expected_program(program_id) for program_id in program_ids]
 
     @ddt.data(
         None,
@@ -62,42 +43,15 @@ class ProgramsViewTests(TestCaseWithAuthentication):
         ['not-real-program'].extend(CourseSamples.program_ids),
     )
     def test_all_programs(self, program_ids):
-        self.generate_data()
-        response = self.authenticated_get(self.path(program_ids=program_ids, exclude=('created',)))
-        self.assertEquals(response.status_code, 200)
-        expected = sorted(self.all_expected_programs(program_ids=program_ids), key=lambda x: x['program_id'])
-        actual = sorted(response.data, key=lambda x: x['program_id'])
-        self.assertListEqual(actual, expected)
+        self._test_all_items(program_ids)
 
     @ddt.data(*CourseSamples.program_ids)
     def test_one_course(self, program_id):
-        self.generate_data()
-        response = self.authenticated_get(self.path(program_ids=[program_id], exclude=('created',)))
-        self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, [self.expected_program(program_id)])
+        self._test_one_item(program_id)
 
     @ddt.data(
         ['program_id'],
         ['program_type', 'program_title'],
     )
     def test_fields(self, fields):
-        self.generate_data()
-        response = self.authenticated_get(self.path(fields=fields))
-        self.assertEquals(response.status_code, 200)
-
-        # remove fields not requested from expected results
-        expected_programs = self.all_expected_programs()
-        for expected_program in expected_programs:
-            for field_to_remove in set(expected_program.keys()) - set(fields):
-                expected_program.pop(field_to_remove)
-
-        self.assertListEqual(response.data, expected_programs)
-
-    def test_no_programs(self):
-        response = self.authenticated_get(self.path())
-        self.assertEquals(response.status_code, 404)
-
-    def test_no_matching_courses(self):
-        self.generate_data()
-        response = self.authenticated_get(self.path(program_ids=['no-program-found']))
-        self.assertEquals(response.status_code, 404)
+        self._test_fields(fields)

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -34,6 +34,7 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
         program.update([
             ('program_type', 'Demo'),
             ('program_title', 'Test'),
+            ('courses', [CourseSamples.course_ids[0]])
         ])
         return program
 

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r'^videos/', include('analytics_data_api.v0.urls.videos', 'videos')),
     url('^', include('analytics_data_api.v0.urls.learners', 'learners')),
     url('^', include('analytics_data_api.v0.urls.course_summaries', 'course_summaries')),
+    url('^', include('analytics_data_api.v0.urls.programs', 'programs')),
 
     # pylint: disable=no-value-for-parameter
     url(r'^authenticated/$', RedirectView.as_view(url=reverse_lazy('authenticated')), name='authenticated'),

--- a/analytics_data_api/v0/urls/programs.py
+++ b/analytics_data_api/v0/urls/programs.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from analytics_data_api.v0.views import programs as views
+
+urlpatterns = [
+    url(r'^programs/$', views.ProgramsView.as_view(), name='programs'),
+]

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -12,8 +12,8 @@ from analytics_data_api.v0.exceptions import CourseNotSpecifiedError
 from analytics_data_api.v0.views.utils import (
     raise_404_if_none,
     split_query_argument,
+    validate_course_id
 )
-import analytics_data_api.utils as utils
 
 
 class CourseViewMixin(object):
@@ -28,7 +28,7 @@ class CourseViewMixin(object):
 
         if not self.course_id:
             raise CourseNotSpecifiedError()
-        utils.validate_course_id(self.course_id)
+        validate_course_id(self.course_id)
         return super(CourseViewMixin, self).get(request, *args, **kwargs)
 
 

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -1,7 +1,18 @@
+from itertools import groupby
+
+from django.db import models
+from django.db.models import Q
+from django.utils import timezone
+
+from rest_framework import generics, serializers
+
 from opaque_keys.edx.keys import CourseKey
 
-from django.utils import timezone
 from analytics_data_api.v0.exceptions import CourseNotSpecifiedError
+from analytics_data_api.v0.views.utils import (
+    raise_404_if_none,
+    split_query_argument,
+)
 import analytics_data_api.utils as utils
 
 
@@ -97,3 +108,118 @@ class CsvViewMixin(object):
         if request.META.get('HTTP_ACCEPT') == u'text/csv':
             response['Content-Disposition'] = u'attachment; filename={}'.format(self.get_csv_filename())
         return super(CsvViewMixin, self).finalize_response(request, response, *args, **kwargs)
+
+
+class APIListView(generics.ListAPIView):
+    """
+    An abstract view to store common code for views that return a list of data.
+
+    **Example Requests**
+
+        GET /api/v0/some_endpoint/
+            Returns full list of serialized models with all default fields.
+
+        GET /api/v0/some_endpoint/?ids={id},{id}
+            Returns list of serialized models with IDs that match an ID in the given
+            `ids` query parameter with all default fields.
+
+        GET /api/v0/some_endpoint/?ids={id},{id}&fields={some_field},{some_field}
+            Returns list of serialized models with IDs that match an ID in the given
+            `ids` query parameter with only the fields in the given `fields` query parameter.
+
+        GET /api/v0/some_endpoint/?ids={id},{id}&exclude={some_field},{some_field}
+            Returns list of serialized models with IDs that match an ID in the given
+            `ids` query parameter with all fields except those in the given `exclude` query
+            parameter.
+
+    **Response Values**
+
+        Since this is an abstract class, this view just returns an empty list.
+
+    **Parameters**
+
+        This view supports filtering the results by a given list of IDs. It also supports
+        explicitly specifying the fields to include in each result with `fields` as well of
+        the fields to exclude with `exclude`.
+
+        ids -- The comma-separated list of identifiers for which results are filtered to.
+            For example, 'edX/DemoX/Demo_Course,course-v1:edX+DemoX+Demo_2016'. Default is to
+            return all courses.
+        fields -- The comma-separated fields to return in the response.
+            For example, 'course_id,created'. Default is to return all fields.
+        exclude -- The comma-separated fields to exclude in the response.
+            For example, 'course_id,created'. Default is to not exclude any fields.
+    """
+    ids = None
+    fields = None
+    exclude = None
+    always_exclude = []
+    serializer_class = serializers.ModelSerializer
+    model = models.Model
+    model_id = 'id'
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs.update({
+            'context': self.get_serializer_context(),
+            'fields': self.fields,
+            'exclude': self.exclude
+        })
+        return self.get_serializer_class()(*args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        query_params = self.request.query_params
+        self.fields = split_query_argument(query_params.get('fields'))
+        exclude = split_query_argument(query_params.get('exclude'))
+        self.exclude = self.always_exclude + (exclude if exclude else [])
+        self.ids = split_query_argument(query_params.get('ids'))
+        self.verify_ids()
+
+        return super(APIListView, self).get(request, *args, **kwargs)
+
+    def verify_ids(self):
+        pass  # to be implemented in subclasses
+
+    def default_result(self, id):
+        """Default result with fields pre-populated to default values."""
+        result = {
+            self.model_id: id,
+        }
+        return result
+
+    def get_result_from_model(self, model, base_result=None, field_list=None):
+        field_list = field_list if field_list else [f.name for f in self.model._meta.get_fields()]
+        result = base_result if base_result else {}
+        result.update({field: getattr(model, field) for field in field_list})
+        return result
+
+    def postprocess_result(self, result):
+        """Applies some business logic to final result without access to any data from the original model."""
+        return result
+
+    def group_by_id(self, queryset):
+        """Return results aggregated by a distinct ID."""
+        formatted_results = []
+        for id, model_group in groupby(queryset, lambda x: (getattr(x, self.model_id))):
+            result = self.default_result(id)
+
+            for model in model_group:
+                result = self.get_result_from_model(model, base_result=result)
+
+            result = self.postprocess_result(result)
+            formatted_results.append(result)
+
+        return formatted_results
+
+    def get_query(self):
+        return reduce(lambda q, id: q | Q(id=id), self.ids, Q())
+
+    @raise_404_if_none
+    def get_queryset(self):
+        if self.ids:
+            queryset = self.model.objects.filter(self.get_query())
+        else:
+            queryset = self.model.objects.all()
+
+        results = self.group_by_id(queryset)
+
+        return results

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -179,15 +179,17 @@ class APIListView(generics.ListAPIView):
     def verify_ids(self):
         pass  # to be implemented in subclasses
 
-    def default_result(self, id):
+    def default_result(self, item_id):
         """Default result with fields pre-populated to default values."""
         result = {
-            self.model_id: id,
+            self.model_id: item_id,
         }
         return result
 
     def get_result_from_model(self, model, base_result=None, field_list=None):
+        # pylint: disable=protected-access,locally-enabled
         field_list = field_list if field_list else [f.name for f in self.model._meta.get_fields()]
+        # pylint: enable=protected-access,locally-enabled
         result = base_result if base_result else {}
         result.update({field: getattr(model, field) for field in field_list})
         return result
@@ -199,8 +201,8 @@ class APIListView(generics.ListAPIView):
     def group_by_id(self, queryset):
         """Return results aggregated by a distinct ID."""
         formatted_results = []
-        for id, model_group in groupby(queryset, lambda x: (getattr(x, self.model_id))):
-            result = self.default_result(id)
+        for item_id, model_group in groupby(queryset, lambda x: (getattr(x, self.model_id))):
+            result = self.default_result(item_id)
 
             for model in model_group:
                 result = self.get_result_from_model(model, base_result=result)
@@ -211,7 +213,7 @@ class APIListView(generics.ListAPIView):
         return formatted_results
 
     def get_query(self):
-        return reduce(lambda q, id: q | Q(id=id), self.ids, Q())
+        return reduce(lambda q, item_id: q | Q(id=item_id), self.ids, Q())
 
     @raise_404_if_none
     def get_queryset(self):

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -187,9 +187,8 @@ class APIListView(generics.ListAPIView):
         return result
 
     def get_result_from_model(self, model, base_result=None, field_list=None):
-        # pylint: disable=protected-access,locally-enabled
-        field_list = field_list if field_list else [f.name for f in self.model._meta.get_fields()]
-        # pylint: enable=protected-access,locally-enabled
+        field_list = (field_list if field_list else
+                      [f.name for f in self.model._meta.get_fields()])  # pylint: disable=protected-access
         result = base_result if base_result else {}
         result.update({field: getattr(model, field) for field in field_list})
         return result

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -68,6 +68,7 @@ class CourseSummariesView(generics.ListAPIView):
     def get(self, request, *args, **kwargs):
         query_params = self.request.query_params
         self.fields = split_query_argument(query_params.get('fields'))
+        self.exclude = split_query_argument(query_params.get('exclude'))
         self.course_ids = split_query_argument(query_params.get('course_ids'))
         if self.course_ids is not None:
             for course_id in self.course_ids:

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -51,6 +51,7 @@ class CourseSummariesView(generics.ListAPIView):
     """
     course_ids = None
     fields = None
+    exclude = ('programs',)
     serializer_class = serializers.CourseMetaSummaryEnrollmentSerializer
     programs_serializer_class = serializers.CourseProgramMetadataSerializer
     model = models.CourseMetaSummaryEnrollment
@@ -60,6 +61,7 @@ class CourseSummariesView(generics.ListAPIView):
         kwargs.update({
             'context': self.get_serializer_context(),
             'fields': self.fields,
+            'exclude': self.exclude
         })
         return self.get_serializer_class()(*args, **kwargs)
 
@@ -145,5 +147,9 @@ class CourseSummariesView(generics.ListAPIView):
             queryset = self.model.objects.all()
 
         summaries = self.group_by_mode(queryset)
-        summaries = self.add_programs(summaries)
+
+        if self.exclude and 'programs' not in self.exclude:
+            # don't do expensive looping for programs if we are just going to throw it away
+            summaries = self.add_programs(summaries)
+
         return summaries

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -1,25 +1,20 @@
-from itertools import groupby
-
 from django.db.models import Q
-
-from rest_framework import generics
 
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
+from analytics_data_api.v0.views import APIListView
 from analytics_data_api.v0.views.utils import (
-    raise_404_if_none,
-    split_query_argument,
     validate_course_id,
 )
 
 
-class CourseSummariesView(generics.ListAPIView):
+class CourseSummariesView(APIListView):
     """
     Returns summary information for courses.
 
     **Example Request**
 
-        GET /api/v0/course_summaries/?course_ids={course_id},{course_id}
+        GET /api/v0/course_summaries/?ids={course_id},{course_id}
 
     **Response Values**
 
@@ -48,109 +43,80 @@ class CourseSummariesView(generics.ListAPIView):
             return all courses.
         fields -- The comma-separated fields to return in the response.
             For example, 'course_id,created'.  Default is to return all fields.
+        exclude -- The comma-separated fields to exclude in the response.
+            For example, 'course_id,created'.  Default is to exclude the programs array.
     """
-    course_ids = None
-    fields = None
     exclude = ('programs',)
     serializer_class = serializers.CourseMetaSummaryEnrollmentSerializer
     programs_serializer_class = serializers.CourseProgramMetadataSerializer
     model = models.CourseMetaSummaryEnrollment
+    model_id = 'course_id'
     programs_model = models.CourseProgramMetadata
+    count_fields = ('count', 'cumulative_count', 'count_change_7_days')  # are initialized to 0 by default
+    summary_meta_fields = ['catalog_course_title', 'catalog_course', 'start_time', 'end_time',
+                           'pacing_type', 'availability']  # fields to extract from summary model
 
-    def get_serializer(self, *args, **kwargs):
-        kwargs.update({
-            'context': self.get_serializer_context(),
-            'fields': self.fields,
-            'exclude': self.exclude
-        })
-        return self.get_serializer_class()(*args, **kwargs)
+    def verify_ids(self):
+        if self.ids is not None:
+            for id in self.ids:
+                validate_course_id(id)
 
-    def get(self, request, *args, **kwargs):
-        query_params = self.request.query_params
-        self.fields = split_query_argument(query_params.get('fields'))
-        self.exclude = split_query_argument(query_params.get('exclude'))
-        self.course_ids = split_query_argument(query_params.get('course_ids'))
-        if self.course_ids is not None:
-            for course_id in self.course_ids:
-                validate_course_id(course_id)
-
-        return super(CourseSummariesView, self).get(request, *args, **kwargs)
-
-    def default_summary(self, course_id, count_fields):
+    def default_result(self, id):
         """Default summary with fields populated to default levels."""
-        summary = {
-            'course_id': course_id,
+        summary = super(CourseSummariesView, self).default_result(id)
+        summary.update({
             'created': None,
             'enrollment_modes': {},
-        }
-        summary.update({field: 0 for field in count_fields})
+        })
+        summary.update({field: 0 for field in self.count_fields})
         summary['enrollment_modes'].update({
             mode: {
-                count_field: 0 for count_field in count_fields
+                count_field: 0 for count_field in self.count_fields
             } for mode in enrollment_modes.ALL
         })
         return summary
 
-    def group_by_mode(self, queryset):
-        """Return enrollment counts for nested in each mode and top-level enrollment counts."""
-        formatted_data = []
-        for course_id, summaries in groupby(queryset, lambda x: (x.course_id)):
-            count_fields = ['count', 'count_change_7_days', 'cumulative_count']
-            item = self.default_summary(course_id, count_fields)
+    def get_result_from_model(self, model, base_result=None):
+        result = super(CourseSummariesView, self).get_result_from_model(model, base_result=base_result,
+                                                                        field_list=self.summary_meta_fields)
+        result['enrollment_modes'].update({
+            model.enrollment_mode: {field: getattr(model, field) for field in self.count_fields}
+        })
 
-            # aggregate the enrollment counts for each mode
-            for summary in summaries:
-                summary_meta_fields = ['catalog_course_title', 'catalog_course', 'start_time', 'end_time',
-                                       'pacing_type', 'availability']
-                item.update({field: getattr(summary, field) for field in summary_meta_fields})
-                item['enrollment_modes'].update({
-                    summary.enrollment_mode: {field: getattr(summary, field) for field in count_fields}
-                })
+        # treat the most recent as the authoritative created date -- should be all the same
+        result['created'] = max(model.created, result['created']) if result['created'] else model.created
 
-                # treat the most recent as the authoritative created date -- should be all the same
-                item['created'] = max(summary.created, item['created']) if item['created'] else summary.created
+        # update totals for all counts
+        result.update({field: result[field] + getattr(model, field) for field in self.count_fields})
 
-                # update totals for all counts
-                item.update({field: item[field] + getattr(summary, field) for field in count_fields})
+        return result
 
-            # Merge professional with non verified professional
-            modes = item['enrollment_modes']
-            prof_no_id_mode = modes.pop(enrollment_modes.PROFESSIONAL_NO_ID, {})
-            prof_mode = modes[enrollment_modes.PROFESSIONAL]
-            for count_key in count_fields:
-                prof_mode[count_key] = prof_mode.get(count_key, 0) + prof_no_id_mode.pop(count_key, 0)
+    def postprocess_result(self, result):
+        # Merge professional with non verified professional
+        modes = result['enrollment_modes']
+        prof_no_id_mode = modes.pop(enrollment_modes.PROFESSIONAL_NO_ID, {})
+        prof_mode = modes[enrollment_modes.PROFESSIONAL]
+        for count_key in self.count_fields:
+            prof_mode[count_key] = prof_mode.get(count_key, 0) + prof_no_id_mode.pop(count_key, 0)
 
-            # AN-8236 replace "Starting Soon" to "Upcoming" availability to collapse the two into one value
-            if item['availability'] == 'Starting Soon':
-                item['availability'] = 'Upcoming'
-
-            formatted_data.append(item)
-
-        return formatted_data
-
-    def add_programs(self, summaries):
-        """Query for programs attached to each course and include them in each course summary"""
-        for summary in summaries:
-            summary['programs'] = []
-            queryset = self.programs_model.objects.filter(course_id=summary['course_id'])
-            for program in queryset:
-                program = self.programs_serializer_class(program)
-                summary['programs'].append(program.data['program_id'])
-        return summaries
-
-    @raise_404_if_none
-    def get_queryset(self):
-        if self.course_ids:
-            # create an OR query for course IDs that match
-            query = reduce(lambda q, course_id: q | Q(course_id=course_id), self.course_ids, Q())
-            queryset = self.model.objects.filter(query)
-        else:
-            queryset = self.model.objects.all()
-
-        summaries = self.group_by_mode(queryset)
+        # AN-8236 replace "Starting Soon" to "Upcoming" availability to collapse the two into one value
+        if result['availability'] == 'Starting Soon':
+            result['availability'] = 'Upcoming'
 
         if self.exclude and 'programs' not in self.exclude:
             # don't do expensive looping for programs if we are just going to throw it away
-            summaries = self.add_programs(summaries)
+            result = self.add_programs(result)
 
-        return summaries
+        return result
+
+    def add_programs(self, result):
+        """Query for programs attached to a course and include them (just the IDs) in the course summary dict"""
+        result['programs'] = []
+        queryset = self.programs_model.objects.filter(course_id=result['course_id'])
+        for program in queryset:
+            program = self.programs_serializer_class(program)
+            result['programs'].append(program.data['program_id'])
+        return result
+
+    def get_query(self):
+        return reduce(lambda q, id: q | Q(course_id=id), self.ids, Q())

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -58,12 +58,12 @@ class CourseSummariesView(APIListView):
 
     def verify_ids(self):
         if self.ids is not None:
-            for id in self.ids:
-                validate_course_id(id)
+            for item_id in self.ids:
+                validate_course_id(item_id)
 
-    def default_result(self, id):
+    def default_result(self, item_id):
         """Default summary with fields populated to default levels."""
-        summary = super(CourseSummariesView, self).default_result(id)
+        summary = super(CourseSummariesView, self).default_result(item_id)
         summary.update({
             'created': None,
             'enrollment_modes': {},
@@ -76,7 +76,7 @@ class CourseSummariesView(APIListView):
         })
         return summary
 
-    def get_result_from_model(self, model, base_result=None):
+    def get_result_from_model(self, model, base_result=None, field_list=None):
         result = super(CourseSummariesView, self).get_result_from_model(model, base_result=base_result,
                                                                         field_list=self.summary_meta_fields)
         result['enrollment_modes'].update({
@@ -119,4 +119,4 @@ class CourseSummariesView(APIListView):
         return result
 
     def get_query(self):
-        return reduce(lambda q, id: q | Q(course_id=id), self.ids, Q())
+        return reduce(lambda q, item_id: q | Q(course_id=item_id), self.ids, Q())

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -46,6 +46,8 @@ class CourseSummariesView(APIListView):
             For example, 'course_id,created'.  Default is to return all fields.
         exclude -- The comma-separated fields to exclude in the response.
             For example, 'course_id,created'.  Default is to exclude the programs array.
+        programs -- If included in the query parameters, will find each courses' program IDs
+            and include them in the response.
     """
     serializer_class = serializers.CourseMetaSummaryEnrollmentSerializer
     programs_serializer_class = serializers.CourseProgramMetadataSerializer

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -1,12 +1,7 @@
-from itertools import groupby
-
 from django.db.models import Q
 
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.views import APIListView
-from analytics_data_api.v0.views.utils import (
-    split_query_argument,
-)
 
 
 class ProgramsView(APIListView):
@@ -43,10 +38,10 @@ class ProgramsView(APIListView):
     model_id = 'program_id'
     program_meta_fields = ['program_type', 'program_title']
 
-    def default_result(self, id):
+    def default_result(self, item_id):
         """Default program with id, empty metadata, and empty courses array."""
         program = {
-            'program_id': id,
+            'program_id': item_id,
             'program_type': '',
             'program_title': '',
             'created': None,
@@ -54,7 +49,7 @@ class ProgramsView(APIListView):
         }
         return program
 
-    def get_result_from_model(self, model, base_result=None):
+    def get_result_from_model(self, model, base_result=None, field_list=None):
         result = super(ProgramsView, self).get_result_from_model(model, base_result=base_result,
                                                                  field_list=self.program_meta_fields)
         result['courses'].append(model.course_id)
@@ -65,4 +60,4 @@ class ProgramsView(APIListView):
         return result
 
     def get_query(self):
-        return reduce(lambda q, id: q | Q(program_id=id), self.ids, Q())
+        return reduce(lambda q, item_id: q | Q(program_id=item_id), self.ids, Q())

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -1,10 +1,13 @@
 from itertools import groupby
 
+from django.db.models import Q
+
 from rest_framework import generics
 
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.views.utils import (
     raise_404_if_none,
+    split_query_argument,
 )
 
 
@@ -35,7 +38,9 @@ class ProgramsView(generics.ListAPIView):
             For example, 'program_id,created'.  Default is to return all fields.
     """
     program_ids = None
-    fields = ('program_id', 'program_type', 'program_title')
+    always_exclude = ['course_id']  # original model has course_id, but the serializer does not (after aggregation)
+    fields = None
+    exclude = None
     serializer_class = serializers.CourseProgramMetadataSerializer
     model = models.CourseProgramMetadata
 
@@ -43,8 +48,18 @@ class ProgramsView(generics.ListAPIView):
         kwargs.update({
             'context': self.get_serializer_context(),
             'fields': self.fields,
+            'exclude': self.exclude
         })
         return self.get_serializer_class()(*args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        query_params = self.request.query_params
+        self.fields = split_query_argument(query_params.get('fields'))
+        exclude = split_query_argument(query_params.get('exclude'))
+        self.exclude = self.always_exclude + (exclude if exclude else [])
+        self.program_ids = split_query_argument(query_params.get('program_ids'))
+
+        return super(ProgramsView, self).get(request, *args, **kwargs)
 
     def default_program(self, program_id):
         """Default program with id, empty metadata, and empty courses array."""
@@ -77,6 +92,12 @@ class ProgramsView(generics.ListAPIView):
 
     @raise_404_if_none
     def get_queryset(self):
-        queryset = self.model.objects.all()
+        if self.program_ids:
+            # create an OR query for course IDs that match
+            query = reduce(lambda q, program_id: q | Q(program_id=program_id), self.program_ids, Q())
+            queryset = self.model.objects.filter(query)
+        else:
+            queryset = self.model.objects.all()
+
         programs = self.group_by_program(queryset)
         return programs

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -1,0 +1,82 @@
+from itertools import groupby
+
+from rest_framework import generics
+
+from analytics_data_api.v0 import models, serializers
+from analytics_data_api.v0.views.utils import (
+    raise_404_if_none,
+)
+
+
+class ProgramsView(generics.ListAPIView):
+    """
+    Returns metadata information for programs.
+
+    **Example Request**
+
+        GET /api/v0/course_programs/?program_ids={program_id},{program_id}
+
+    **Response Values**
+
+        Returns metadata for every program:
+
+            * program_id: The ID of the program for which data is returned.
+            * program_type: The type of the program
+            * program_title: The title of the program
+            * created: The date the counts were computed.
+
+    **Parameters**
+
+        Results can be filed to the course IDs specified or limited to the fields.
+
+        program_ids -- The comma-separated program identifiers for which metadata is requested.
+            Default is to return all programs.
+        fields -- The comma-separated fields to return in the response.
+            For example, 'program_id,created'.  Default is to return all fields.
+    """
+    program_ids = None
+    fields = ('program_id', 'program_type', 'program_title')
+    serializer_class = serializers.CourseProgramMetadataSerializer
+    model = models.CourseProgramMetadata
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs.update({
+            'context': self.get_serializer_context(),
+            'fields': self.fields,
+        })
+        return self.get_serializer_class()(*args, **kwargs)
+
+    def default_program(self, program_id):
+        """Default program with id, empty metadata, and empty courses array."""
+        program = {
+            'program_id': program_id,
+            'program_type': '',
+            'program_title': '',
+            'created': None,
+            'courses': [],
+        }
+        return program
+
+    def group_by_program(self, queryset):
+        """Return enrollment counts for nested in each mode and top-level enrollment counts."""
+        formatted_data = []
+        for program_id, programs in groupby(queryset, lambda x: (x.program_id)):
+            item = self.default_program(program_id)
+
+            # aggregate the program/course pairs to one program item with course_ids array
+            for program in programs:
+                program_meta_fields = ['program_type', 'program_title']
+                item.update({field: getattr(program, field) for field in program_meta_fields})
+                item['courses'].append(program.course_id)
+
+                # treat the most recent as the authoritative created date -- should be all the same
+                item['created'] = max(program.created, item['created']) if item['created'] else program.created
+
+            formatted_data.append(item)
+        return formatted_data
+
+    @raise_404_if_none
+    def get_queryset(self):
+        queryset = self.model.objects.all()
+        programs = self.group_by_program(queryset)
+        return programs


### PR DESCRIPTION
This PR also adds an option to include a list of program ids that each course is associated with in `course_summaries`. It's disabled by default right now for performance concerns. As we develop the UI in Insights, we can decide whether it is worth enabling.

Because the new `programs` endpoint is so similar to the `course_summaries` endpoint, I refactored the common parts of each into an inheritable abstract view `APIListView` and `APIListViewTestMixin`.

I wanted to try to performance test the new endpoint more, but I'm having trouble doing that right now (I think it might have to do with our VPN being down).