### PR TITLE
Upgrading to django 1.11

### DIFF
--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -9,6 +9,7 @@ import urllib
 
 import ddt
 from django.conf import settings
+from django.utils import timezone
 from django_dynamic_fixture import G
 import pytz
 from opaque_keys.edx.keys import CourseKey
@@ -592,10 +593,12 @@ class CourseProblemsListViewTests(TestCaseWithAuthentication):
         # natural order and ensure the view properly sorts the objects before grouping.
         module_id = u'i4x://test/problem/1'
         alt_module_id = u'i4x://test/problem/2'
-        created = datetime.datetime.utcnow()
+        created = timezone.now()
         alt_created = created + datetime.timedelta(seconds=2)
         date_time_format = '%Y-%m-%d %H:%M:%S'
 
+        # using string representations of dates will cause "DateTimeField time zone support" RuntimeWarning
+        # however, using the date with timezone causes conversion errors
         o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=course_id, module_id=module_id,
                correct=True, last_response_count=100, created=created.strftime(date_time_format))
         o2 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=course_id, module_id=alt_module_id,
@@ -661,7 +664,7 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
             'learning_outcome': ['Learned nothing', 'Learned a few things', 'Learned everything']
         }
 
-        created = datetime.datetime.utcnow()
+        created = timezone.now()
         alt_created = created + datetime.timedelta(seconds=2)
 
         G(models.ProblemsAndTags, course_id=course_id, module_id=module_id,
@@ -728,18 +731,17 @@ class CourseVideosListViewTests(TestCaseWithAuthentication):
 
         module_id = 'i4x-test-video-1'
         video_id = 'v1d30'
-        created = datetime.datetime.utcnow()
-        date_time_format = '%Y-%m-%d %H:%M:%S'
+        created = timezone.now()
         G(models.Video, course_id=course_id, encoded_module_id=module_id,
           pipeline_video_id=video_id, duration=100, segment_length=1, users_at_start=50, users_at_end=10,
-          created=created.strftime(date_time_format))
+          created=created)
 
         alt_module_id = 'i4x-test-video-2'
         alt_video_id = 'a1d30'
         alt_created = created + datetime.timedelta(seconds=10)
         G(models.Video, course_id=course_id, encoded_module_id=alt_module_id,
           pipeline_video_id=alt_video_id, duration=200, segment_length=5, users_at_start=1050, users_at_end=50,
-          created=alt_created.strftime(date_time_format))
+          created=alt_created)
 
         expected = [
             {

--- a/analytics_data_api/v0/tests/views/test_videos.py
+++ b/analytics_data_api/v0/tests/views/test_videos.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.conf import settings
+from django.utils import timezone
 from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models
@@ -17,17 +18,16 @@ class VideoTimelineTests(TestCaseWithAuthentication):
         G(models.VideoTimeline)
 
         video_id = 'v1d30'
-        created = datetime.datetime.utcnow()
-        date_time_format = '%Y-%m-%d %H:%M:%S'
+        created = timezone.now()
         G(models.VideoTimeline, pipeline_video_id=video_id, segment=0, num_users=10,
-          num_views=50, created=created.strftime(date_time_format))
+          num_views=50, created=created)
         G(models.VideoTimeline, pipeline_video_id=video_id, segment=1, num_users=1,
-          num_views=1234, created=created.strftime(date_time_format))
+          num_views=1234, created=created)
 
         alt_video_id = 'altv1d30'
         alt_created = created + datetime.timedelta(seconds=17)
         G(models.VideoTimeline, pipeline_video_id=alt_video_id, segment=0, num_users=10231,
-          num_views=834828, created=alt_created.strftime(date_time_format))
+          num_views=834828, created=alt_created)
 
         expected = [
             {

--- a/analyticsdataserver/urls.py
+++ b/analyticsdataserver/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     url(r'^api-token-auth/', obtain_auth_token),
 
     url(r'^api/', include('analytics_data_api.urls', 'api')),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
+    url(r'^docs/', views.SwaggerSchemaView.as_view()),
 
     url(r'^status/$', views.StatusView.as_view(), name='status'),
     url(r'^authenticated/$', views.AuthenticationTestView.as_view(), name='authenticated'),

--- a/analyticsdataserver/views.py
+++ b/analyticsdataserver/views.py
@@ -1,10 +1,12 @@
 from django.conf import settings
 from django.db import connections
 from django.http import HttpResponse
-from rest_framework import permissions
+from rest_framework import permissions, schemas
+from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
 
 
 def handle_internal_server_error(_request):
@@ -25,6 +27,21 @@ def _handle_error(status_code):
     renderer = JSONRenderer()
     content_type = '{media}; charset={charset}'.format(media=renderer.media_type, charset=renderer.charset)
     return HttpResponse(renderer.render(info), content_type=content_type, status=status_code)
+
+
+class SwaggerSchemaView(APIView):
+    """
+    Renders the swagger schema for the documentation regardless of permissions.
+    """
+    permission_classes = [AllowAny]
+    renderer_classes = [
+        OpenAPIRenderer,
+        SwaggerUIRenderer
+    ]
+
+    def get(self, _request):
+        generator = schemas.SchemaGenerator(title='Analytics API')
+        return Response(generator.get_schema())
 
 
 class StatusView(APIView):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,13 +1,13 @@
 boto==2.42.0                        # MIT
-Django==1.10.7 						# BSD License
-django-countries==4.0               # MIT
-djangorestframework==3.5.3			# BSD
-django-rest-swagger==0.3.8  		# BSD
-djangorestframework-csv==1.4.1		# BSD
-django-storages==1.5.1              # BSD
+Django==1.11 						# BSD License
+django-countries==4.5               # MIT
+djangorestframework==3.6.2			# BSD
+django-rest-swagger==2.1.2  		# BSD
+djangorestframework-csv==2.0.0		# BSD
+django-storages==1.5.2              # BSD
 elasticsearch-dsl==0.0.11           # Apache 2.0
-ordered-set==2.0.1                  # MIT
-tqdm==4.10.0                        # MIT
+ordered-set==2.0.2                  # MIT
+tqdm==4.11.2                        # MIT
 
 # markdown is used by swagger for rendering the api docs
 Markdown==2.6.6    					# BSD

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,16 +1,16 @@
 # Test dependencies go here.
 -r base.txt
-coverage==4.2
+coverage==4.4.1
 ddt==1.1.1
 diff-cover >= 0.9.9
-django-dynamic-fixture==1.9.0
+django-dynamic-fixture==1.9.5
 django-nose==1.4.4
 mock==2.0.0
-nose-exclude==0.4.1
+nose-exclude==0.5.0
 nose-ignore-docstring==0.2
 nose==1.3.7
 pep257==0.7.0
 pep8==1.7.0
-pylint==1.6.4
-pytz==2016.6.1
+pylint==1.7.1
+pytz==2017.2
 responses==0.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,6 +11,6 @@ nose-ignore-docstring==0.2
 nose==1.3.7
 pep257==0.7.0
 pep8==1.7.0
-pylint==1.7.1
+pylint==1.6.5
 pytz==2017.2
 responses==0.5.1

--- a/templates/rest_framework_swagger/index.html
+++ b/templates/rest_framework_swagger/index.html
@@ -1,87 +1,40 @@
+{% extends "rest_framework_swagger/index.html" %}
+
 {% load staticfiles %}
-<!DOCTYPE html>
-<html>
-<head>
-  <title>edX Analytics API</title>
-  <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
-  <link href='{% static "rest_framework_swagger/css/highlight.default.css" %}' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='{% static "rest_framework_swagger/css/rest_framework_swagger.css" %}' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='{% static "rest_framework_swagger/css/screen.css" %}' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='{% static "css/edx-swagger.css" %}' media='screen' rel='stylesheet' type='text/css'/>
-  <script type="text/javascript" src="{% static 'rest_framework_swagger/lib/shred.bundle.js' %}"></script>
-  <script src='{% static "rest_framework_swagger/lib/jquery-1.8.0.min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/jquery.slideto.min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/jquery.wiggle.min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/jquery.ba-bbq.min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/jquery.cookie.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/handlebars-1.0.0.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/underscore-min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/backbone-min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/swagger.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/swagger-ui.min.js" %}' type='text/javascript'></script>
-  <script src='{% static "rest_framework_swagger/lib/highlight.7.3.pack.js" %}' type='text/javascript'></script>
 
-  <link rel="icon" type="image/x-icon" href='{% static "images/favicon.ico" %}' />
+{% block header %}
+    <div id="header">
+      <div class="swagger-ui-wrap">
+          <form id='api_selector'>
+            <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+            <div class='input'><input placeholder="API Key" id="input_apiKey" name="apiKey" type="text"/></div>
+          </form>
+      </div>
+    </div>
+{% endblock %}
 
+{% block extra_scripts %}
   <script type="text/javascript">
     $(function () {
       window.swaggerUi = new SwaggerUi({
-      url: "{{ swagger_settings.discovery_url }}",
-      apiKey: "{{ swagger_settings.api_key }}",
-      dom_id: "swagger-ui-container",
-      supportedSubmitMethods: {{ swagger_settings.enabled_methods }},
-      onComplete: function(swaggerApi, swaggerUi){
-        if(console) {
-          console.log("Loaded SwaggerUI")
+        url: '',
+        dom_id: 'swagger-ui-container'
+      });
+
+      // this sets the authorization token so calls to the API can made via swagger
+      $('#input_apiKey').change(function() {
+        var key = $('#input_apiKey')[0].value;
+        console.log('key: ' + key);
+        if(key && key.trim() !== '') {
+          console.log('added key ' + key);
+          window.swaggerUi.api.clientAuthorizations.add('key',
+            new SwaggerClient.ApiKeyAuthorization('Authorization', 'Token ' + key, 'header')
+          );
         }
-        $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
-      },
-      onFailure: function(data) {
-        if(console) {
-          console.log("Unable to Load SwaggerUI");
-          console.log(data);
-        }
-      },
-      docExpansion: "none"
+      });
+      window.swaggerUi.load();
     });
-
-    $('#input_apiKey').change(function() {
-      var key = $('#input_apiKey')[0].value;
-      console.log("key: " + key);
-      if(key && key.trim() != "") {
-        console.log("added key " + key);
-        window.authorizations.add("key", new ApiKeyAuthorization("Authorization", "Token " + key, "header"));
-      }
-    })
-    {% if swagger_settings.api_key %}
-    window.authorizations.add("key", new ApiKeyAuthorization("Authorization", "Token " + "{{ swagger_settings.api_key }}", "header"));
-    {% endif %}
-    window.swaggerUi.load();
-  });
-
   </script>
-</head>
 
-<body>
-<div id='header'>
-  <div class="swagger-ui-wrap">
-    <a id="logo" class="edx-logo" href="http://code.edx.org/"></a>
-
-    <form id='api_selector'>
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div class='input'><input placeholder="API Key" id="input_apiKey" name="apiKey" type="text"/></div>
-      <div class='input'><a id="explore" href="#">Explore</a></div>
-    </form>
-  </div>
-</div>
-
-<div id="message-bar" class="swagger-ui-wrap">
-  &nbsp;
-</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap">
-
-</div>
-
-</body>
-
-</html>
+  <script src='{% static "rest_framework_swagger/init.js" %}' type='text/javascript'></script>
+{% endblock %}


### PR DESCRIPTION
I updated a bunch of packages, mostly importantly django to 1.11.  Unfortunately, updating to 1.11.1 results in a GDAL failure, which is fixed in [1.11.2](https://docs.djangoproject.com/en/1.11/releases/1.11.2/) (under development).

Changes of note:
* You'll see a lot of updates to the dates to use timezones in the tests in order to remove warnings
* I also refactored `rest_framework_swagger/index.html` to extend swagger's default template view.