### PR TITLE
Fix course summaries query arg to use course_ids

### DIFF
--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -139,7 +139,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         [CourseSamples.course_ids[0], 'malformed-course-id'],
     )
     def test_bad_course_id(self, course_ids):
-        response = self.authenticated_get(self.path(ids=course_ids))
+        response = self.authenticated_get(self.path(course_ids=course_ids))
         self.verify_bad_course_id(response)
 
     def test_collapse_upcoming(self):

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -15,7 +15,7 @@ class CourseSummariesView(APIListView):
 
     **Example Request**
 
-        GET /api/v0/course_summaries/?ids={course_id},{course_id}
+        GET /api/v0/course_summaries/?course_ids={course_id},{course_id}
 
     **Response Values**
 
@@ -63,7 +63,7 @@ class CourseSummariesView(APIListView):
         programs = split_query_argument(query_params.get('programs'))
         if not programs:
             self.always_exclude = self.always_exclude + ['programs']
-        self.ids = split_query_argument(query_params.get('ids'))
+        self.ids = split_query_argument(query_params.get('course_ids'))
         self.verify_ids()
         response = super(CourseSummariesView, self).get(request, *args, **kwargs)
         return response


### PR DESCRIPTION
I noticed that the query arg changed from `course_ids` to just `ids` (inadvertently?).  This parameter used to be `course_ids` and the change to `ids` is inconsistent with what's specified in the api client, https://github.com/edx/edx-analytics-data-api-client/blob/master/analyticsclient/course_summaries.py#L31.