### PR TITLE
Patch bump to django.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto==2.42.0                        # MIT
-Django==1.11 						# BSD License
+Django==1.11.2						# BSD License
 django-countries==4.5               # MIT
 djangorestframework==3.6.2			# BSD
 django-rest-swagger==2.1.2  		# BSD


### PR DESCRIPTION
Instead of going to 1.11.1 when this was originally upgraded, I left this at 1.11 because of a GDAL detection error that caused the build to fail.  This is now resolved in [1.11.2](https://docs.djangoproject.com/en/1.11/releases/1.11.2/).

I was going to make a ticket to upgrade, but this seemed faster?

Please review, @edx/educator-dahlia 