### PR TITLE
EDUCATOR-464: Add POST method to course_summaries/

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Jason Bau <jbau@stanford.edu>
 John Jarvis <jarv@edx.org>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Eric Fischer <efischer@edx.org>
+Kyle McCormick <kylemccor@gmail.com>

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -22,6 +22,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
     list_name = 'course_summaries'
     default_ids = CourseSamples.course_ids
     always_exclude = ['created', 'programs']
+    test_post_method = True
 
     def setUp(self):
         super(CourseSummariesViewTests, self).setUp()
@@ -135,7 +136,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
     )
     def test_empty_modes(self, modes):
         self.generate_data(modes=modes)
-        response = self.authenticated_get(self.path(exclude=self.always_exclude))
+        response = self.validated_request(exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
         self.assertItemsEqual(response.data, self.all_expected_results(modes=modes))
 
@@ -144,13 +145,13 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         [CourseSamples.course_ids[0], 'malformed-course-id'],
     )
     def test_bad_course_id(self, course_ids):
-        response = self.authenticated_get(self.path(ids=course_ids))
+        response = self.validated_request(ids=course_ids)
         self.verify_bad_course_id(response)
 
     def test_collapse_upcoming(self):
         self.generate_data(availability='Starting Soon')
         self.generate_data(ids=['foo/bar/baz'], availability='Upcoming')
-        response = self.authenticated_get(self.path(exclude=self.always_exclude))
+        response = self.validated_request(exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
 
         expected_summaries = self.all_expected_results(availability='Upcoming')
@@ -161,13 +162,13 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
 
     def test_programs(self):
         self.generate_data(programs=True)
-        response = self.authenticated_get(self.path(exclude=self.always_exclude[:1], programs=['True']))
+        response = self.validated_request(exclude=self.always_exclude[:1], programs=['True'])
         self.assertEquals(response.status_code, 200)
         self.assertItemsEqual(response.data, self.all_expected_results(programs=True))
 
     @ddt.data('passing_users', )
     def test_exclude(self, field):
         self.generate_data()
-        response = self.authenticated_get(self.path(exclude=[field]))
+        response = self.validated_request(exclude=[field])
         self.assertEquals(response.status_code, 200)
         self.assertEquals(str(response.data).count(field), 0)

--- a/analyticsdataserver/tests.py
+++ b/analyticsdataserver/tests.py
@@ -27,7 +27,15 @@ class TestCaseWithAuthentication(TestCase):
 
     def authenticated_get(self, path, data=None, follow=True, **extra):
         data = data or {}
-        return self.client.get(path, data, follow, HTTP_AUTHORIZATION='Token ' + self.token.key, **extra)
+        return self.client.get(
+            path=path, data=data, follow=follow, HTTP_AUTHORIZATION='Token ' + self.token.key, **extra
+        )
+
+    def authenticated_post(self, path, data=None, follow=True, **extra):
+        data = data or {}
+        return self.client.post(
+            path=path, data=data, follow=follow, HTTP_AUTHORIZATION='Token ' + self.token.key, **extra
+        )
 
 
 @contextmanager


### PR DESCRIPTION
The course_summaries/ currently supports only the GET method. A client can restrict the number of course summaries returned from the endpoint by passing in a list of desired course IDs in the `course_ids` parameter. However, this is not practically usable, as the number of IDs many clients would want to pass in would make the URL too long. So, Insights currently does not use the `course_ids` parameter, and instead fetches *every* course summary and filters them on the client side. Fetching every summary incurs a response time of ~5s.

To fix this, this PR adds a POST method to this endpoint. The POST method functions exactly the same as the GET method, except that all parameters are passed in the request body, allowing a much larger number of course IDs to be passed in. (It is understood that this is not the semantic meaning of the POST verb, however, this is not an uncommon workaround to URL length restrictions).

[This PR](https://github.com/edx/edx-analytics-data-api-client/pull/33/commits) updates the Analytics API Client to use the new POST method, and [this PR](https://github.com/edx/edx-analytics-dashboard/pull/690) updates Insights to take advantage of the course ID filtering now usable in the client.

JIRA Ticket: [EDUCATOR-464](https://openedx.atlassian.net/browse/EDUCATOR-464).

TODO:
- [x] Write tests
- [x] Get tests to pass
- [ ] Get thumbs

@edx/educator-dahlia 
