### PR TITLE
EDUCATOR-604: Fix course_summaries/ and programs/ to expect correct query param

### DIFF
--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -94,6 +94,7 @@ class VerifyCsvResponseMixin(object):
 class APIListViewTestMixin(object):
     model = None
     model_id = 'id'
+    ids_param = 'ids'
     serializer = None
     expected_results = []
     list_name = 'list'
@@ -102,7 +103,7 @@ class APIListViewTestMixin(object):
 
     def path(self, ids=None, fields=None, exclude=None, **kwargs):
         query_params = {}
-        for query_arg, data in zip(['ids', 'fields', 'exclude'], [ids, fields, exclude]) + kwargs.items():
+        for query_arg, data in zip([self.ids_param, 'fields', 'exclude'], [ids, fields, exclude]) + kwargs.items():
             if data:
                 query_params[query_arg] = ','.join(data)
         query_string = '?{}'.format(urlencode(query_params))

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -16,6 +16,7 @@ from analyticsdataserver.tests import TestCaseWithAuthentication
 class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseMetaSummaryEnrollment
     model_id = 'course_id'
+    ids_param = 'course_ids'
     serializer = serializers.CourseMetaSummaryEnrollmentSerializer
     expected_summaries = []
     list_name = 'course_summaries'
@@ -143,7 +144,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         [CourseSamples.course_ids[0], 'malformed-course-id'],
     )
     def test_bad_course_id(self, course_ids):
-        response = self.authenticated_get(self.path(course_ids=course_ids))
+        response = self.authenticated_get(self.path(ids=course_ids))
         self.verify_bad_course_id(response)
 
     def test_collapse_upcoming(self):

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -11,6 +11,7 @@ from analyticsdataserver.tests import TestCaseWithAuthentication
 class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseProgramMetadata
     model_id = 'program_id'
+    ids_param = 'program_ids'
     serializer = serializers.CourseProgramMetadataSerializer
     expected_programs = []
     list_name = 'programs'

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -155,6 +155,7 @@ class APIListView(generics.ListAPIView):
     exclude = None
     always_exclude = []
     model_id_field = 'id'
+    ids_param = 'ids'
 
     def get_serializer(self, *args, **kwargs):
         kwargs.update({
@@ -169,9 +170,18 @@ class APIListView(generics.ListAPIView):
         self.fields = split_query_argument(query_params.get('fields'))
         exclude = split_query_argument(query_params.get('exclude'))
         self.exclude = self.always_exclude + (exclude if exclude else [])
-        self.ids = split_query_argument(query_params.get('ids'))
+        self.ids = split_query_argument(query_params.get(self.ids_param))
+        self.verify_ids()
 
         return super(APIListView, self).get(request, *args, **kwargs)
+
+    def verify_ids(self):
+        """
+        Optionally raise an exception if any of the IDs set as self.ids are invalid.
+        By default, no verification is done.
+        Subclasses can override this if they wish to perform verification.
+        """
+        pass
 
     def base_field_dict(self, item_id):
         """Default result with fields pre-populated to default values."""

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -53,6 +53,7 @@ class CourseSummariesView(APIListView):
     programs_serializer_class = serializers.CourseProgramMetadataSerializer
     model = models.CourseMetaSummaryEnrollment
     model_id_field = 'course_id'
+    ids_param = 'course_ids'
     programs_model = models.CourseProgramMetadata
     count_fields = ('count', 'cumulative_count', 'count_change_7_days',
                     'passing_users')  # are initialized to 0 by default
@@ -64,12 +65,14 @@ class CourseSummariesView(APIListView):
         programs = split_query_argument(query_params.get('programs'))
         if not programs:
             self.always_exclude = self.always_exclude + ['programs']
-        self.ids = split_query_argument(query_params.get('course_ids'))
-        self.verify_ids()
         response = super(CourseSummariesView, self).get(request, *args, **kwargs)
         return response
 
     def verify_ids(self):
+        """
+        Raise an exception if any of the course IDs set as self.ids are invalid.
+        Overrides APIListView.verify_ids.
+        """
         if self.ids is not None:
             for item_id in self.ids:
                 validate_course_id(item_id)

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -35,6 +35,7 @@ class ProgramsView(APIListView):
     serializer_class = serializers.CourseProgramMetadataSerializer
     model = models.CourseProgramMetadata
     model_id_field = 'program_id'
+    ids_param = 'program_ids'
     program_meta_fields = ['program_type', 'program_title']
 
     def base_field_dict(self, program_id):


### PR DESCRIPTION
The docstring for the course_summaries/ endpoint says it accept a `course_ids` parameter, allowing clients to specify which course summaries to return. However, it is coded such that the accepted parameter name is `ids`. The same is true for the programs/ endpoint with `program_ids` versus `ids`. The tests were written in such a way that this behavior passed. This PR fixes all those issues.

Ticket: [EDUCATOR-604](https://openedx.atlassian.net/browse/EDUCATOR-604)
@edx/educator-dahlia 