### PR TITLE
Remove limit on HTTP request parameter count

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -312,6 +312,13 @@ DEFAULT_PAGE_SIZE = 25
 MAX_PAGE_SIZE = 100
 AGGREGATE_PAGE_SIZE = 10
 
+# Maximum number of GET/POST parameters that will be read before a
+# SuspiciousOperation (TooManyFieldsSent) is raised.
+# None indicates no maximum.
+# We need to set this to None so that we can pass in a large number of Course IDs
+# to course_summaries/
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None
+
 ########## END ANALYTICS DATA API CONFIGURATION
 
 


### PR DESCRIPTION
Fixes bug where course_summaries/ gives a 400 because more course IDs
were being passed in than allowed, causing a TooManyFieldsSent error.

See [this](https://rpm.newrelic.com/accounts/88178/applications/3428570/traced_errors/03519b38-5822-11e7-8968-0242ac11000f_0_6848) trace for example.