### PR TITLE
EDUCATOR-570 Fix multi-course program grouping bug

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -93,7 +93,7 @@ class CourseProgramMetadata(BaseCourseModel):
 
     class Meta(BaseCourseModel.Meta):
         db_table = 'course_program_metadata'
-        ordering = ('course_id',)
+        ordering = ('program_id',)
         unique_together = [('course_id', 'program_id',)]
 
 

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -134,10 +134,10 @@ class APIListViewTestMixin(object):
         for item_id in ids:
             self.create_model(item_id, **kwargs)
 
-    def expected_result(self, item_id):
+    def expected_result(self, item_id, **kwargs):
         result = OrderedDict([
             (self.model_id, item_id),
-        ])
+        ].extend(kwargs.items()))
         return result
 
     def all_expected_results(self, ids=None, **kwargs):

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -134,10 +134,10 @@ class APIListViewTestMixin(object):
         for item_id in ids:
             self.create_model(item_id, **kwargs)
 
-    def expected_result(self, item_id, **kwargs):
+    def expected_result(self, item_id):
         result = OrderedDict([
             (self.model_id, item_id),
-        ].extend(kwargs.items()))
+        ])
         return result
 
     def all_expected_results(self, ids=None, **kwargs):

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -54,7 +54,8 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
         return [self.expected_result(item_id, course_ids=course_id, **kwargs)
                 for item_id, course_id in zip(ids, course_ids)]
 
-    def expected_result(self, item_id, course_ids=None, **kwargs):
+    # pylint: disable=arguments-differ
+    def expected_result(self, item_id, course_ids=None):
         """Expected program metadata to populate with data."""
         if course_ids is None:
             course_ids = [self.course_id]

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -54,7 +54,7 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
         return [self.expected_result(item_id, course_ids=course_id, **kwargs)
                 for item_id, course_id in zip(ids, course_ids)]
 
-    def expected_result(self, item_id, course_ids=None):
+    def expected_result(self, item_id, course_ids=None, **kwargs):
         """Expected program metadata to populate with data."""
         if course_ids is None:
             course_ids = [self.course_id]
@@ -88,7 +88,7 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
 
     @ddt.data(
         (None, None),
-        (CourseSamples.program_ids, [[id] for id in CourseSamples.course_ids]),
+        (CourseSamples.program_ids, [[cid] for cid in CourseSamples.course_ids]),
         (CourseSamples.program_ids, [CourseSamples.course_ids[1:3],
                                      CourseSamples.course_ids[0:2],
                                      CourseSamples.course_ids[0:3]]),


### PR DESCRIPTION
I think the issue described in [EDUCATOR-570](https://openedx.atlassian.net/browse/EDUCATOR-570) is because programs are occurring more than once in the programs endpoint JSON output, each with different course_ids lists (see the "Before" JSON below). Insights just selects the first instance and so it's missing a lot of the course_ids that only appear in the other instances. I found out that this is because `group_by_id` is dependent on the ordering of the CourseProgramMetadata table. We mistakenly have it ordered by course_id. I changed it to program_id which results in the correct "After" JSON below.

I also overhauled the programs tests so that it tests with multi-course programs (we were just the same single course for all test programs before). The test fails unless the ordering of the table is by program_id.

Before (failed program grouping due to course ordering):
```json
...
  {
    "program_id": "4a002529-560c-486d-8069-19a2bc1320d8",
    "program_type": "MicroMasters",
    "program_title": "Digital Leadership",
    "course_ids": [
      "course-v1:BUx+QD501x+2T2017",
      "course-v1:BUx+QD502x+3T2017"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "be3e00d2-0680-4771-aea5-1fa0dc8ada2a",
    "program_type": "MicroMasters",
    "program_title": "Digital Product Management",
    "course_ids": [
      "course-v1:BUx+QD503x+2T2017",
      "course-v1:BUx+QD504x+3T2017",
      "course-v1:BUx+QD505x+2T2017"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "4a002529-560c-486d-8069-19a2bc1320d8",
    "program_type": "MicroMasters",
    "program_title": "Digital Leadership",
    "course_ids": [
      "course-v1:BUx+QD505x+2T2017"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "be3e00d2-0680-4771-aea5-1fa0dc8ada2a",
    "program_type": "MicroMasters",
    "program_title": "Digital Product Management",
    "course_ids": [
      "course-v1:BUx+QD601x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "4a002529-560c-486d-8069-19a2bc1320d8",
    "program_type": "MicroMasters",
    "program_title": "Digital Leadership",
    "course_ids": [
      "course-v1:BUx+QD601x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "be3e00d2-0680-4771-aea5-1fa0dc8ada2a",
    "program_type": "MicroMasters",
    "program_title": "Digital Product Management",
    "course_ids": [
      "course-v1:BUx+QD602x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
  {
    "program_id": "4a002529-560c-486d-8069-19a2bc1320d8",
    "program_type": "MicroMasters",
    "program_title": "Digital Leadership",
    "course_ids": [
      "course-v1:BUx+QD602x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
...
```

After (programs listed exactly once, all course_ids included):
```json
...
  {
    "program_id": "4a002529-560c-486d-8069-19a2bc1320d8",
    "program_type": "MicroMasters",
    "program_title": "Digital Leadership",
    "course_ids": [
      "course-v1:BUx+QD501x+2T2017",
      "course-v1:BUx+QD502x+3T2017",
      "course-v1:BUx+QD505x+2T2017",
      "course-v1:BUx+QD601x+1T2018",
      "course-v1:BUx+QD602x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
...
  {
    "program_id": "be3e00d2-0680-4771-aea5-1fa0dc8ada2a",
    "program_type": "MicroMasters",
    "program_title": "Digital Product Management",
    "course_ids": [
      "course-v1:BUx+QD503x+2T2017",
      "course-v1:BUx+QD504x+3T2017",
      "course-v1:BUx+QD505x+2T2017",
      "course-v1:BUx+QD601x+1T2018",
      "course-v1:BUx+QD602x+1T2018"
    ],
    "created": "2017-05-03T145241"
  },
```

@edx/educator-dahlia 