### PR TITLE
upgrade django from 1.11.2 to 1.11.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto==2.42.0                        # MIT
-Django==1.11.2						# BSD License
+Django==1.11.5						# BSD License
 django-countries==4.5               # MIT
 djangorestframework==3.6.2			# BSD
 django-rest-swagger==2.1.2  		# BSD


### PR DESCRIPTION
[EDUCATOR-1362](https://openedx.atlassian.net/browse/EDUCATOR-1362)
There are security and other bug fixes in [Django 1.11.5 release](https://docs.djangoproject.com/en/1.11/releases/1.11.5/).
Version is changed in requirement file. 
Is there any thing we need to look at for this update?
FYI: @awaisdar001  