### PR TITLE
Install optional requirements for production.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ requirements:
 
 production-requirements:
 	pip install -r requirements.txt
+	pip install -r requirements/optional.txt
 
 test.install_elasticsearch:
 	curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$(ELASTICSEARCH_VERSION).zip


### PR DESCRIPTION
Master sandbox builds have been breaking for us ever since the `analytics_api` role was [updated to be based on `edx_django_service` role](https://github.com/edx/configuration/commit/7a9202ab6d10985bd72d3c5f805f5a48f707905b).

The reason is that prior to the change, `requirements/optional.txt` [were always installed by the role](https://github.com/edx/configuration/blob/9d1e24e8821f7b5e9e3eab9af065cd0947e66e3b/playbooks/roles/analytics_api/defaults/main.yml#L176-L179), but after the switch, [`make production-requirements` is used to install all dependencies](https://github.com/edx/configuration/blob/0978dd0d7bdb0f3c13207fe25cab40b2f19c75cc/playbooks/roles/edx_django_service/tasks/main.yml#L91-L99).

That means that currently the newerlic package from `requirements/optional.txt` does not get installed, causing the service to fail when you try to run it with newrelic enabled.

**JIRA tickets**: [OSPR-2413](https://openedx.atlassian.net/browse/OSPR-2413)

**Dependencies**: None

**Merge deadline**: "ASAP" since this is breaking master builds.

**Testing instructions**:

1. Run the [edx_sandbox.yml playbook|https://github.com/edx/configuration/blob/master/playbooks/edx_sandbox.yml] without this patch with `COMMON_ENABLE_NEWRELIC_APP` set to `True`.
2. Observe that the playbook fails at the "[edx_django_service : restart the application]" for `analytics_api` task with `ERROR (spawn error)`. The reason is that the newrelic package from optional requirements is not installed.
3. Run `edx_sandbox.yml` playbook again, but configure it to use this branch of `edx-analytics-data-api`.
4. Observe that it runs successfully.


**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] (?)