### PR TITLE
Allow CORS for API access for local development

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -157,6 +157,7 @@ TEMPLATES = [
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
 MIDDLEWARE_CLASSES = (
     # Default Django middleware.
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -198,7 +199,8 @@ THIRD_PARTY_APPS = (
     'rest_framework_swagger',
     'django_countries',
     'storages',
-    'enterprise_data'
+    'enterprise_data',
+    'corsheaders',
 )
 
 LOCAL_APPS = (

--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -81,4 +81,8 @@ JWT_AUTH.update({
     'JWT_VERIFY_AUDIENCE': False,
 })
 
+CORS_ORIGIN_WHITELIST = (
+    'localhost:1991'
+)
+
 ########## END ANALYTICS DATA API CONFIGURATION

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,3 +18,4 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client                 # Apache 2.0
 edx-drf-extensions
 edx-enterprise-data==0.1.9
+django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko
+django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-rest-swagger==2.1.2
@@ -52,7 +53,7 @@ markupsafe==1.0           # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.0.4                # via stevedore
+pbr==4.2.0                # via stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.6.0             # via edx-enterprise-data, tox
 py==1.5.4                 # via edx-enterprise-data, tox
@@ -60,7 +61,7 @@ pyasn1==0.4.3             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.4              # via celery, django, edx-enterprise-data, vertica-python
@@ -71,7 +72,7 @@ s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,6 +20,7 @@ colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko
+django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-rest-swagger==2.1.2
@@ -52,7 +53,7 @@ markupsafe==1.0           # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.0.4                # via stevedore
+pbr==4.2.0                # via stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.6.0             # via edx-enterprise-data, tox
 py==1.5.4                 # via edx-enterprise-data, tox
@@ -60,7 +61,7 @@ pyasn1==0.4.3             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.4              # via celery, django, edx-enterprise-data, vertica-python
@@ -71,7 +72,7 @@ s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,6 +20,7 @@ colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko
+django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-rest-swagger==2.1.2
@@ -52,7 +53,7 @@ markupsafe==1.0           # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.0.4                # via stevedore
+pbr==4.2.0                # via stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.6.0             # via edx-enterprise-data, tox
 py==1.5.4                 # via edx-enterprise-data, tox
@@ -61,7 +62,7 @@ pycparser==2.18           # via cffi, edx-enterprise-data
 pygments==2.2.0           # via sphinx
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.4              # via celery, django, edx-enterprise-data, vertica-python
@@ -73,7 +74,7 @@ simplejson==3.16.0        # via django-rest-swagger
 six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 sphinx==1.2.1
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,6 +20,7 @@ colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko
+django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-rest-swagger==2.1.2
@@ -42,7 +43,7 @@ first==2.0.1              # via edx-enterprise-data, pip-tools
 future==0.16.0            # via edx-enterprise-data, vertica-python
 futures==3.2.0            # via s3transfer
 gevent==1.0.2
-greenlet==0.4.13          # via gevent
+greenlet==0.4.14          # via gevent
 gunicorn==19.6.0
 idna==2.7                 # via cryptography, edx-enterprise-data
 ipaddress==1.0.22         # via cryptography
@@ -58,7 +59,7 @@ openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
 path.py==8.2.1
-pbr==4.0.4                # via stevedore
+pbr==4.2.0                # via stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.6.0             # via edx-enterprise-data, tox
 py==1.5.4                 # via edx-enterprise-data, tox
@@ -66,7 +67,7 @@ pyasn1==0.4.3             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.4              # via celery, django, edx-enterprise-data, vertica-python
@@ -77,7 +78,7 @@ s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,8 @@ coreschema==0.0.4         # via coreapi
 coverage==4.4.1
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko
 ddt==1.1.1
-diff-cover==1.0.3
+diff-cover==1.0.4
+django-cors-headers==2.4.0
 django-countries==4.5
 django-dynamic-fixture==1.9.5
 django-fernet-fields==0.5  # via edx-enterprise-data
@@ -52,7 +53,7 @@ funcsigs==1.0.2           # via mock
 future==0.16.0            # via edx-enterprise-data, vertica-python
 futures==3.2.0            # via isort, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
-inflect==0.3.1            # via jinja2-pluralize
+inflect==1.0.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography
 isort==4.3.4              # via pylint
 itypes==1.1.0             # via coreapi
@@ -71,7 +72,7 @@ nose==1.3.7
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.0.4                # via mock, stevedore
+pbr==4.2.0                # via mock, stevedore
 pep257==0.7.0
 pep8==1.7.0
 pip-tools==2.0.2          # via edx-enterprise-data
@@ -83,7 +84,7 @@ pygments==2.2.0           # via diff-cover
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pylint==1.6.5
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.4
@@ -95,7 +96,7 @@ s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 six==1.11.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, mock, pip-tools, pylint, pynacl, python-dateutil, responses, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data


### PR DESCRIPTION
This enables CORS during local development. localhost:1991 is whitelisted
which is the default port used by standalone frontends built from the
edx-frontend-cookiecutter.

This is necessary for the edx-portal to connect to the data-api during local development. Because we're using authorization header and not the session cookie we didn't need `CORS_ALLOW_CREDENTIALS`