### PR TITLE
Add metrics for requests.

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -157,6 +157,7 @@ TEMPLATES = [
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
 MIDDLEWARE_CLASSES = (
     # Default Django middleware.
+    'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -164,6 +165,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'edx_django_utils.cache.middleware.TieredCacheMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'analytics_data_api.v0.middleware.LearnerEngagementTimelineNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.LearnerNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.CourseNotSpecifiedErrorMiddleware',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,6 +15,7 @@ Markdown==2.6.6                     # BSD:markdown is used by swagger for render
 edx-ccx-keys==0.2.1
 edx-django-release-util
 edx-opaque-keys==0.4.0
+edx-django-utils
 edx-rest-api-client                 # Apache 2.0
 edx-drf-extensions
 edx-enterprise-data==0.2.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,10 +32,11 @@ djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-drf-extensions==1.2.4
+edx-django-utils==0.4.1
+edx-drf-extensions==1.6.1
 edx-enterprise-data==0.2.4
 edx-opaque-keys==0.4
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,10 +32,11 @@ djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-drf-extensions==1.2.4
+edx-django-utils==0.4.1
+edx-drf-extensions==1.6.1
 edx-enterprise-data==0.2.4
 edx-opaque-keys==0.4
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -32,10 +32,11 @@ djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore, edx-enterprise-data, sphinx
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-drf-extensions==1.2.4
+edx-django-utils==0.4.1
+edx-drf-extensions==1.6.1
 edx-enterprise-data==0.2.4
 edx-opaque-keys==0.4
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -32,10 +32,11 @@ djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-drf-extensions==1.2.4
+edx-django-utils==0.4.1
+edx-drf-extensions==1.6.1
 edx-enterprise-data==0.2.4
 edx-opaque-keys==0.4
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -41,10 +41,11 @@ djangorestframework==3.6.3
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-drf-extensions==1.2.4
+edx-django-utils==0.4.1
+edx-drf-extensions==1.6.1
 edx-enterprise-data==0.2.4
 edx-opaque-keys==0.4
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data


### PR DESCRIPTION
ARCH-193

Adds middleware that will record request level metrics.

Reviewer: Note that `make upgrade` failed for me, so part of this upgrade I had to do manually.