### PR TITLE
Upgrade edx-enterprise-data to 0.2.5 and unpin many requirements

### DIFF
--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -577,7 +577,7 @@ class CourseMetaSummaryEnrollmentSerializer(ModelSerializerWithCreatedField, Dyn
         exclude = ('id', 'start_time', 'end_time', 'enrollment_mode')
 
 
-class CourseProgramMetadataSerializer(ModelSerializerWithCreatedField, DynamicFieldsModelSerializer):
+class CourseProgramMetadataSerializer(DynamicFieldsModelSerializer):
     """
     Serializer for course and the programs it is under.
     """
@@ -593,4 +593,4 @@ class CourseProgramMetadataSerializer(ModelSerializerWithCreatedField, DynamicFi
         model = models.CourseProgramMetadata
         # excluding course-related fields because the serialized output will be embedded in a course object
         # with those fields already defined
-        exclude = ('id', 'created', 'course_id')
+        exclude = ('id', 'course_id')

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,20 +3,20 @@
 boto==2.42.0                        # MIT
 django==1.11.15                     # BSD License
 django-countries==4.5               # MIT
-djangorestframework==3.6.3          # BSD
-django-rest-swagger==2.1.2          # BSD
-djangorestframework-csv==2.0.0      # BSD
-django-storages==1.5.2              # BSD
+djangorestframework                 # BSD
+django-rest-swagger                 # BSD
+djangorestframework-csv             # BSD
+django-storages                     # BSD
 elasticsearch-dsl==0.0.11           # Apache 2.0
 ordered-set==2.0.2                  # MIT
 tqdm==4.11.2                        # MIT
 urllib3==1.21.1                     # MIT
 Markdown==2.6.6                     # BSD:markdown is used by swagger for rendering the api docs
-edx-ccx-keys==0.2.1
+edx-ccx-keys
 edx-django-release-util
-edx-opaque-keys==0.4.0
+edx-opaque-keys
 edx-django-utils
 edx-rest-api-client                 # Apache 2.0
 edx-drf-extensions
-edx-enterprise-data==0.2.4
+edx-enterprise-data
 django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,25 +23,26 @@ cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, param
 django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
-django-rest-swagger==2.1.2
-django-storages==1.5.2
+django-rest-swagger==2.2.0
+django-storages==1.6.6
+django-waffle==0.14.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
-djangorestframework-csv==2.0.0
+djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
-edx-drf-extensions==1.6.1
-edx-enterprise-data==0.2.4
-edx-opaque-keys==0.4
+edx-django-utils==0.5.1
+edx-drf-extensions==1.6.2
+edx-enterprise-data==0.2.5
+edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data
 first==2.0.1              # via edx-enterprise-data, pip-tools
-future==0.16.0            # via edx-enterprise-data, vertica-python
+future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data
@@ -51,29 +52,35 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
+newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.2.0                # via stevedore
+pbr==4.2.0                # via edx-enterprise-data, stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.7.1             # via edx-enterprise-data, tox
-py==1.5.4                 # via edx-enterprise-data, tox
+psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
+pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
+pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
-requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, slumber
+requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, pyjwkest, slumber
+rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
+semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
+six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pyjwkest, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.29.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,25 +23,26 @@ cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, param
 django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
-django-rest-swagger==2.1.2
-django-storages==1.5.2
+django-rest-swagger==2.2.0
+django-storages==1.6.6
+django-waffle==0.14.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
-djangorestframework-csv==2.0.0
+djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
-edx-drf-extensions==1.6.1
-edx-enterprise-data==0.2.4
-edx-opaque-keys==0.4
+edx-django-utils==0.5.1
+edx-drf-extensions==1.6.2
+edx-enterprise-data==0.2.5
+edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data
 first==2.0.1              # via edx-enterprise-data, pip-tools
-future==0.16.0            # via edx-enterprise-data, vertica-python
+future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data
@@ -51,29 +52,35 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
+newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.2.0                # via stevedore
+pbr==4.2.0                # via edx-enterprise-data, stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.7.1             # via edx-enterprise-data, tox
-py==1.5.4                 # via edx-enterprise-data, tox
+psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
+pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
+pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
-requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, slumber
+requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, pyjwkest, slumber
+rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
+semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
+six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pyjwkest, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.29.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,25 +23,26 @@ cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, param
 django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
-django-rest-swagger==2.1.2
-django-storages==1.5.2
+django-rest-swagger==2.2.0
+django-storages==1.6.6
+django-waffle==0.14.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
-djangorestframework-csv==2.0.0
+djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data, sphinx
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
-edx-drf-extensions==1.6.1
-edx-enterprise-data==0.2.4
-edx-opaque-keys==0.4
+edx-django-utils==0.5.1
+edx-drf-extensions==1.6.2
+edx-enterprise-data==0.2.5
+edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data
 first==2.0.1              # via edx-enterprise-data, pip-tools
-future==0.16.0            # via edx-enterprise-data, vertica-python
+future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data
@@ -51,31 +52,37 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
+newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.2.0                # via stevedore
+pbr==4.2.0                # via edx-enterprise-data, stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.7.1             # via edx-enterprise-data, tox
-py==1.5.4                 # via edx-enterprise-data, tox
+psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
+pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pygments==2.2.0           # via sphinx
+pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
-requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, slumber
+requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, pyjwkest, slumber
+rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
+semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
+six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pyjwkest, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 sphinx==1.2.1
-stevedore==1.29.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -7,4 +7,4 @@ PyYAML                              # MIT
 gevent==1.0.2
 gunicorn==19.6.0                    # MIT
 path.py==8.2.1
-newrelic==2.98.0.81                 # New Relic agent for performance monitoring
+newrelic                            # New Relic agent for performance monitoring

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,25 +23,26 @@ cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, param
 django-cors-headers==2.4.0
 django-countries==4.5
 django-fernet-fields==0.5  # via edx-enterprise-data
-django-rest-swagger==2.1.2
-django-storages==1.5.2
+django-rest-swagger==2.2.0
+django-storages==1.6.6
+django-waffle==0.14.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
-djangorestframework-csv==2.0.0
+djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
-edx-drf-extensions==1.6.1
-edx-enterprise-data==0.2.4
-edx-opaque-keys==0.4
+edx-django-utils==0.5.1
+edx-drf-extensions==1.6.2
+edx-enterprise-data==0.2.5
+edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data
 first==2.0.1              # via edx-enterprise-data, pip-tools
-future==0.16.0            # via edx-enterprise-data, vertica-python
+future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 gevent==1.0.2
 greenlet==0.4.14          # via gevent
@@ -55,31 +56,36 @@ kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
 mysql-python==1.2.5
-newrelic==2.98.0.81
+newrelic==4.2.0.100
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
 path.py==8.2.1
-pbr==4.2.0                # via stevedore
+pbr==4.2.0                # via edx-enterprise-data, stevedore
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.7.1             # via edx-enterprise-data, tox
-py==1.5.4                 # via edx-enterprise-data, tox
+psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
+pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
+pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12
-requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, slumber
+requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, pyjwkest, slumber
+rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
+semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pynacl, python-dateutil, stevedore, tox, vertica-python
+six==1.11.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, pip-tools, pyjwkest, pynacl, python-dateutil, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.29.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,26 +32,27 @@ django-countries==4.5
 django-dynamic-fixture==1.9.5
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-nose==1.4.4
-django-rest-swagger==2.1.2
-django-storages==1.5.2
+django-rest-swagger==2.2.0
+django-storages==1.6.6
+django-waffle==0.14.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
-djangorestframework-csv==2.0.0
+djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
-edx-drf-extensions==1.6.1
-edx-enterprise-data==0.2.4
-edx-opaque-keys==0.4
+edx-django-utils==0.5.1
+edx-drf-extensions==1.6.2
+edx-enterprise-data==0.2.5
+edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data
 first==2.0.1              # via edx-enterprise-data, pip-tools
 funcsigs==1.0.2           # via mock
-future==0.16.0            # via edx-enterprise-data, vertica-python
+future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, isort, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
 inflect==1.0.0            # via jinja2-pluralize
@@ -67,37 +68,43 @@ markdown==2.6.6
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
+newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
 nose-exclude==0.5.0
 nose-ignore-docstring==0.2
 nose==1.3.7
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pbr==4.2.0                # via mock, stevedore
+pbr==4.2.0                # via edx-enterprise-data, mock, stevedore
 pep257==0.7.0
 pep8==1.7.0
 pip-tools==2.0.2          # via edx-enterprise-data
 pluggy==0.7.1             # via edx-enterprise-data, tox
-py==1.5.4                 # via edx-enterprise-data, tox
+psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
 pycparser==2.18           # via cffi, edx-enterprise-data
+pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pygments==2.2.0           # via diff-cover
+pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pylint==1.6.5
 pyminizip==0.2.1          # via edx-enterprise-data
-pymongo==3.7.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.2.1             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
-requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, responses, slumber
+requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, pyjwkest, responses, slumber
 responses==0.5.1
+rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
+semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, mock, pip-tools, pylint, pynacl, python-dateutil, responses, stevedore, tox, vertica-python
+six==1.11.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, mock, pip-tools, pyjwkest, pylint, pynacl, python-dateutil, responses, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.29.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data


### PR DESCRIPTION
Unpinned a number of requirements so they would be upgraded as part of
`make upgrade` as recommended by OEP-18. In particular the edx-enterprise-data
django app was not pinning edx-drf-extensions which resulted in 2 different
versions of DRF in the requirements (one for enterprise-data and one for this
IDA).

Upgrading DRF resulting in an assertion failure that was added in DRF 3.7.4
```
Cannot both declare the field 'created' and include it in the CourseProgramMetadataSerializer
'exclude' option. Remove the field or, if inherited from a parent serializer, disable with `created = None`.
```

https://github.com/encode/django-rest-framework/pull/5599

Because the created date was being excluded, it is not needed in the CourseProgramMetadataSerializer and has been removed.