### PR TITLE
Package updates including edx-enterprise-data 0.2.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
-click==6.7                # via edx-enterprise-data, pip-tools
+click==7.0                # via edx-enterprise-data, pip-tools
 colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -34,8 +34,8 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
-edx-enterprise-data==0.2.9
+edx-drf-extensions==1.9.0
+edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
@@ -52,7 +52,7 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
-newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
+newrelic==4.4.1.104       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
@@ -62,13 +62,13 @@ pluggy==0.7.1             # via edx-enterprise-data, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
-pycparser==2.18           # via cffi, edx-enterprise-data
+pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
-pynacl==1.2.1             # via edx-enterprise-data, paramiko
+pynacl==1.3.0             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
-click==6.7                # via edx-enterprise-data, pip-tools
+click==7.0                # via edx-enterprise-data, pip-tools
 colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -34,8 +34,8 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
-edx-enterprise-data==0.2.9
+edx-drf-extensions==1.9.0
+edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
@@ -52,7 +52,7 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
-newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
+newrelic==4.4.1.104       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
@@ -62,13 +62,13 @@ pluggy==0.7.1             # via edx-enterprise-data, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
-pycparser==2.18           # via cffi, edx-enterprise-data
+pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
-pynacl==1.2.1             # via edx-enterprise-data, paramiko
+pynacl==1.3.0             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -15,7 +15,7 @@ boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
-click==6.7                # via edx-enterprise-data, pip-tools
+click==7.0                # via edx-enterprise-data, pip-tools
 colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -34,8 +34,8 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data, sphinx
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
-edx-enterprise-data==0.2.9
+edx-drf-extensions==1.9.0
+edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
@@ -52,7 +52,7 @@ jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
-newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
+newrelic==4.4.1.104       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
@@ -62,14 +62,14 @@ pluggy==0.7.1             # via edx-enterprise-data, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
-pycparser==2.18           # via cffi, edx-enterprise-data
+pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pygments==2.2.0           # via sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
-pynacl==1.2.1             # via edx-enterprise-data, paramiko
+pynacl==1.3.0             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-click==6.7                # via pip-tools
-first==2.0.1              # via pip-tools
-pip-tools==2.0.2
+click==7.0                # via pip-tools
+pip-tools==3.0.0
 six==1.11.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,7 +15,7 @@ boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
-click==6.7                # via edx-enterprise-data, pip-tools
+click==7.0                # via edx-enterprise-data, pip-tools
 colorama==0.3.7           # via awscli, edx-enterprise-data
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -34,8 +34,8 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
-edx-enterprise-data==0.2.9
+edx-drf-extensions==1.9.0
+edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
@@ -45,7 +45,7 @@ first==2.0.1              # via edx-enterprise-data, pip-tools
 future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 gevent==1.0.2
-greenlet==0.4.14          # via gevent
+greenlet==0.4.15          # via gevent
 gunicorn==19.6.0
 idna==2.7                 # via cryptography, edx-enterprise-data
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data
@@ -56,7 +56,7 @@ kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
 markupsafe==1.0           # via jinja2
 mysql-python==1.2.5
-newrelic==4.2.0.100
+newrelic==4.4.1.104
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
@@ -67,13 +67,13 @@ pluggy==0.7.1             # via edx-enterprise-data, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
-pycparser==2.18           # via cffi, edx-enterprise-data
+pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
 pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
-pynacl==1.2.1             # via edx-enterprise-data, paramiko
+pynacl==1.3.0             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5              # via celery, django, edx-enterprise-data, vertica-python
 pyyaml==3.12

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,7 +17,7 @@ boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
-click==6.7                # via edx-enterprise-data, pip-tools
+click==7.0                # via edx-enterprise-data, pip-tools
 colorama==0.3.7           # via awscli, edx-enterprise-data
 configparser==3.5.0       # via pylint
 cookies==2.2.1            # via responses
@@ -43,8 +43,8 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
-edx-enterprise-data==0.2.9
+edx-drf-extensions==1.9.0
+edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11
@@ -55,7 +55,7 @@ funcsigs==1.0.2           # via mock
 future==0.16.0            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, isort, s3transfer
 idna==2.7                 # via cryptography, edx-enterprise-data
-inflect==1.0.0            # via jinja2-pluralize
+inflect==1.0.1            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data
 isort==4.3.4              # via pylint
 itypes==1.1.0             # via coreapi
@@ -68,7 +68,7 @@ markdown==2.6.6
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-newrelic==4.2.0.100       # via edx-django-utils, edx-enterprise-data
+newrelic==4.4.1.104       # via edx-django-utils, edx-enterprise-data
 nose-exclude==0.5.0
 nose-ignore-docstring==0.2
 nose==1.3.7
@@ -83,7 +83,7 @@ pluggy==0.7.1             # via edx-enterprise-data, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py==1.6.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.4             # via edx-enterprise-data, paramiko, rsa
-pycparser==2.18           # via cffi, edx-enterprise-data
+pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.6.6      # via edx-enterprise-data, pyjwkest
 pygments==2.2.0           # via diff-cover
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
@@ -91,7 +91,7 @@ pyjwt==1.6.4              # via djangorestframework-jwt, edx-enterprise-data, ed
 pylint==1.6.5
 pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.1            # via edx-enterprise-data, edx-opaque-keys
-pynacl==1.2.1             # via edx-enterprise-data, paramiko
+pynacl==1.3.0             # via edx-enterprise-data, paramiko
 python-dateutil==2.7.3    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 pytz==2018.5
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data


### PR DESCRIPTION
edx-enterprise-data 0.2.10 - now filters out enrollments that do not have consent_granted when doing calculations for enterpriseUser and EnterpriseLearnerCompletedCourses endpoints

edx-enterprise-data 0.2.11 - Updated external packages for edx-enterprise-data so they're inline with this repo's