### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -167,6 +167,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'analytics_data_api.v0.middleware.LearnerEngagementTimelineNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.LearnerNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.CourseNotSpecifiedErrorMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.9.0
+edx-drf-extensions==1.10.0
 edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.9.0
+edx-drf-extensions==1.10.0
 edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data, sphinx
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.9.0
+edx-drf-extensions==1.10.0
 edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -34,7 +34,7 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.9.0
+edx-drf-extensions==1.10.0
 edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -43,7 +43,7 @@ docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.9.0
+edx-drf-extensions==1.10.0
 edx-enterprise-data==0.2.11
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2


### PR DESCRIPTION
From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233