### PR TITLE
ENT-1189 edx-enterprise-data version bump to 0.2.12

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Kyle McCormick <kylemccor@gmail.com>
 George Babey <gbabey@edx.org>
 Noraiz Anwar <noraizbhatti@gmail.com>
 Mushtaq Ali <mushtaak@gmail.com>
+Zubair Afzal <zubair.fast@gmail.com>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.9.0
-edx-enterprise-data==0.2.11
+edx-enterprise-data==0.2.12
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.9.0
-edx-enterprise-data==0.2.11
+edx-enterprise-data==0.2.12
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.9.0
-edx-enterprise-data==0.2.11
+edx-enterprise-data==0.2.12
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.9.0
-edx-enterprise-data==0.2.11
+edx-enterprise-data==0.2.12
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,7 +44,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.9.0
-edx-enterprise-data==0.2.11
+edx-enterprise-data==0.2.12
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2
 elasticsearch-dsl==0.0.11


### PR DESCRIPTION
Version bump `edx-enterprise-data` from `0.2.11` to `0.2.12`.

**Related PR:** https://github.com/edx/edx-enterprise-data/pull/66