### PR TITLE
ENT-1235 bump edx-enterprise-data version to 1.0.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
-edx-enterprise-data==1.0.7
+edx-enterprise-data==1.0.8
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9
 elasticsearch-dsl==0.0.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
-edx-enterprise-data==1.0.7
+edx-enterprise-data==1.0.8
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9
 elasticsearch-dsl==0.0.11

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
-edx-enterprise-data==1.0.7
+edx-enterprise-data==1.0.8
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9
 elasticsearch-dsl==0.0.11

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,7 +35,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
-edx-enterprise-data==1.0.7
+edx-enterprise-data==1.0.8
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9
 elasticsearch-dsl==0.0.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,7 +44,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
-edx-enterprise-data==1.0.7
+edx-enterprise-data==1.0.8
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9
 elasticsearch-dsl==0.0.11


### PR DESCRIPTION
Bump `edx-enterprise-data` version to `1.0.8` from `1.0.7`.

**This version update includes:**
[Enable audit enrollments filtering on field `user_current_enrollment_mode` for model `EnterpriseEnrollment`](https://github.com/edx/edx-enterprise-data/pull/70)