### PR TITLE
ENT-1603 : Bump edx-enterprise-data version to 1.0.17

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ George Babey <gbabey@edx.org>
 Noraiz Anwar <noraizbhatti@gmail.com>
 Mushtaq Ali <mushtaak@gmail.com>
 Zubair Afzal <zubair.fast@gmail.com>
+Saleem Latif <saleem_ee@hotmail.com>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.16
+edx-enterprise-data==1.0.17
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.16
+edx-enterprise-data==1.0.17
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.16
+edx-enterprise-data==1.0.17
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.16
+edx-enterprise-data==1.0.17
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.16
+edx-enterprise-data==1.0.17
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11


### PR DESCRIPTION
**JIRA Ticket:** [ENT-1603](https://openedx.atlassian.net/browse/ENT-1603)

**Description:**
Version bump contains these changes: https://github.com/edx/edx-enterprise-data/compare/1.0.16...1.0.17