### PR TITLE
edx-enterprise-data version bump to 1.0.18

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Noraiz Anwar <noraizbhatti@gmail.com>
 Mushtaq Ali <mushtaak@gmail.com>
 Zubair Afzal <zubair.fast@gmail.com>
 Saleem Latif <saleem_ee@hotmail.com>
+Muhammad Ammar <mammar@gmail.com>

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -205,6 +205,7 @@ THIRD_PARTY_APPS = (
     'django_countries',
     'storages',
     'enterprise_data',
+    'rules.apps.AutodiscoverRulesConfig',
     'corsheaders',
     'waffle',
 )
@@ -216,6 +217,11 @@ LOCAL_APPS = (
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+
+AUTHENTICATION_BACKENDS = [
+    'rules.permissions.ObjectPermissionBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
 ########## END APP CONFIGURATION
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,73 +7,71 @@
 amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 asn1crypto==0.24.0        # via cryptography, edx-enterprise-data
-atomicwrites==1.2.1       # via edx-enterprise-data, pytest
-attrs==18.2.0             # via edx-enterprise-data, pytest
 awscli==1.11.178          # via edx-enterprise-data
-bcrypt==3.1.5             # via edx-enterprise-data, paramiko
+bcrypt==3.1.6             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
 boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
-certifi==2018.11.29       # via edx-enterprise-data, urllib3
-cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
+certifi==2019.3.9         # via edx-enterprise-data, urllib3
+cffi==1.12.2              # via bcrypt, cryptography, edx-enterprise-data, pynacl
 click==7.0                # via edx-enterprise-data, pip-tools, py2neo
 colorama==0.3.7           # via awscli, edx-enterprise-data, py2neo
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl, urllib3
-django-cors-headers==2.4.0
+django-cors-headers==2.5.2
 django-countries==4.5
+django-crum==0.7.3        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
+django-model-utils==3.1.2  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0
 django-storages==1.7.1
-django-waffle==0.15.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.17
+edx-drf-extensions==2.1.0
+edx-enterprise-data==1.0.18
 edx-opaque-keys==0.4.4
+edx-rbac==0.1.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via edx-enterprise-data, pytest
 future==0.17.1            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.8                 # via cryptography, edx-enterprise-data, urllib3
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data, urllib3
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
-jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
+jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
-markupsafe==1.1.0         # via jinja2
-more-itertools==5.0.0     # via edx-enterprise-data, pytest
-neo4j-driver==1.6.2       # via edx-enterprise-data, py2neo
-neotime==1.0.0            # via edx-enterprise-data, neo4j-driver, py2neo
-newrelic==4.8.0.110       # via edx-django-utils, edx-enterprise-data
+markupsafe==1.1.1         # via jinja2
+neobolt==1.7.4            # via edx-enterprise-data, py2neo
+neotime==1.7.4            # via edx-enterprise-data, py2neo
+newrelic==4.14.0.115      # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pathlib2==2.3.3           # via edx-enterprise-data, pytest
-pbr==5.1.1                # via edx-enterprise-data, stevedore
+pbr==5.1.3                # via edx-enterprise-data, stevedore
 pgpy==0.4.3               # via edx-enterprise-data
-pip-tools==3.2.0          # via edx-enterprise-data
-pluggy==0.8.0             # via edx-enterprise-data, pytest, tox
-prompt-toolkit==1.0.15    # via edx-enterprise-data, py2neo
+pip-tools==3.5.0          # via edx-enterprise-data
+pluggy==0.9.0             # via edx-enterprise-data, tox
+prompt-toolkit==2.0.9     # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-py2neo==4.1.3             # via edx-enterprise-data
-py==1.7.0                 # via edx-enterprise-data, pytest, tox
+py2neo==4.2.0             # via edx-enterprise-data
+py==1.8.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.5             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
-pycryptodomex==3.7.2      # via edx-enterprise-data, pyjwkest
+pycryptodomex==3.7.3      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via edx-enterprise-data, py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
@@ -81,27 +79,26 @@ pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.2            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data, urllib3
-pytest==4.0.2             # via edx-enterprise-data, py2neo
-python-dateutil==2.7.5    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
+python-dateutil==2.8.0    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
-pytz==2018.7              # via celery, django, edx-enterprise-data, neotime, vertica-python
+pytz==2018.9              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
+rules==2.0.1              # via edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
-scandir==1.9.0            # via edx-enterprise-data, pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, neotime, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.30.0         # via edx-enterprise-data, edx-opaque-keys
+stevedore==1.30.1         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.0        # via coreapi
-urllib3[secure]==1.22
+urllib3[secure]==1.24.1
 vertica-python==0.7.3     # via edx-enterprise-data
-virtualenv==16.2.0        # via edx-enterprise-data, tox
+virtualenv==16.4.3        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,73 +7,71 @@
 amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 asn1crypto==0.24.0        # via cryptography, edx-enterprise-data
-atomicwrites==1.2.1       # via edx-enterprise-data, pytest
-attrs==18.2.0             # via edx-enterprise-data, pytest
 awscli==1.11.178          # via edx-enterprise-data
-bcrypt==3.1.5             # via edx-enterprise-data, paramiko
+bcrypt==3.1.6             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
 boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
-certifi==2018.11.29       # via edx-enterprise-data, urllib3
-cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
+certifi==2019.3.9         # via edx-enterprise-data, urllib3
+cffi==1.12.2              # via bcrypt, cryptography, edx-enterprise-data, pynacl
 click==7.0                # via edx-enterprise-data, pip-tools, py2neo
 colorama==0.3.7           # via awscli, edx-enterprise-data, py2neo
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl, urllib3
-django-cors-headers==2.4.0
+django-cors-headers==2.5.2
 django-countries==4.5
+django-crum==0.7.3        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
+django-model-utils==3.1.2  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0
 django-storages==1.7.1
-django-waffle==0.15.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.17
+edx-drf-extensions==2.1.0
+edx-enterprise-data==1.0.18
 edx-opaque-keys==0.4.4
+edx-rbac==0.1.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via edx-enterprise-data, pytest
 future==0.17.1            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.8                 # via cryptography, edx-enterprise-data, urllib3
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data, urllib3
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
-jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
+jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
-markupsafe==1.1.0         # via jinja2
-more-itertools==5.0.0     # via edx-enterprise-data, pytest
-neo4j-driver==1.6.2       # via edx-enterprise-data, py2neo
-neotime==1.0.0            # via edx-enterprise-data, neo4j-driver, py2neo
-newrelic==4.8.0.110       # via edx-django-utils, edx-enterprise-data
+markupsafe==1.1.1         # via jinja2
+neobolt==1.7.4            # via edx-enterprise-data, py2neo
+neotime==1.7.4            # via edx-enterprise-data, py2neo
+newrelic==4.14.0.115      # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pathlib2==2.3.3           # via edx-enterprise-data, pytest
-pbr==5.1.1                # via edx-enterprise-data, stevedore
+pbr==5.1.3                # via edx-enterprise-data, stevedore
 pgpy==0.4.3               # via edx-enterprise-data
-pip-tools==3.2.0          # via edx-enterprise-data
-pluggy==0.8.0             # via edx-enterprise-data, pytest, tox
-prompt_toolkit==1.0.15    # via edx-enterprise-data, py2neo
+pip-tools==3.5.0          # via edx-enterprise-data
+pluggy==0.9.0             # via edx-enterprise-data, tox
+prompt-toolkit==2.0.9     # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-py2neo==4.1.3             # via edx-enterprise-data
-py==1.7.0                 # via edx-enterprise-data, pytest, tox
+py2neo==4.2.0             # via edx-enterprise-data
+py==1.8.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.5             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
-pycryptodomex==3.7.2      # via edx-enterprise-data, pyjwkest
+pycryptodomex==3.7.3      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via edx-enterprise-data, py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
@@ -81,27 +79,26 @@ pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.2            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data, urllib3
-pytest==4.0.2             # via edx-enterprise-data, py2neo
-python-dateutil==2.7.5    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
+python-dateutil==2.8.0    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
-pytz==2018.7              # via celery, django, edx-enterprise-data, neotime, vertica-python
+pytz==2018.9              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
+rules==2.0.1              # via edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
-scandir==1.9.0            # via edx-enterprise-data, pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, neotime, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.30.0         # via edx-enterprise-data, edx-opaque-keys
+stevedore==1.30.1         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.0        # via coreapi
-urllib3[secure]==1.22
+urllib3[secure]==1.24.1
 vertica-python==0.7.3     # via edx-enterprise-data
-virtualenv==16.2.0        # via edx-enterprise-data, tox
+virtualenv==16.4.3        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,73 +7,71 @@
 amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 asn1crypto==0.24.0        # via cryptography, edx-enterprise-data
-atomicwrites==1.2.1       # via edx-enterprise-data, pytest
-attrs==18.2.0             # via edx-enterprise-data, pytest
 awscli==1.11.178          # via edx-enterprise-data
-bcrypt==3.1.5             # via edx-enterprise-data, paramiko
+bcrypt==3.1.6             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
 boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
-certifi==2018.11.29       # via edx-enterprise-data, urllib3
-cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
+certifi==2019.3.9         # via edx-enterprise-data, urllib3
+cffi==1.12.2              # via bcrypt, cryptography, edx-enterprise-data, pynacl
 click==7.0                # via edx-enterprise-data, pip-tools, py2neo
 colorama==0.3.7           # via awscli, edx-enterprise-data, py2neo
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl, urllib3
-django-cors-headers==2.4.0
+django-cors-headers==2.5.2
 django-countries==4.5
+django-crum==0.7.3        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
+django-model-utils==3.1.2  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0
 django-storages==1.7.1
-django-waffle==0.15.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data, sphinx
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.17
+edx-drf-extensions==2.1.0
+edx-enterprise-data==1.0.18
 edx-opaque-keys==0.4.4
+edx-rbac==0.1.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via edx-enterprise-data, pytest
 future==0.17.1            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 idna==2.8                 # via cryptography, edx-enterprise-data, urllib3
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data, urllib3
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema, sphinx
-jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
+jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
-markupsafe==1.1.0         # via jinja2
-more-itertools==5.0.0     # via edx-enterprise-data, pytest
-neo4j-driver==1.6.2       # via edx-enterprise-data, py2neo
-neotime==1.0.0            # via edx-enterprise-data, neo4j-driver, py2neo
-newrelic==4.8.0.110       # via edx-django-utils, edx-enterprise-data
+markupsafe==1.1.1         # via jinja2
+neobolt==1.7.4            # via edx-enterprise-data, py2neo
+neotime==1.7.4            # via edx-enterprise-data, py2neo
+newrelic==4.14.0.115      # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pathlib2==2.3.3           # via edx-enterprise-data, pytest
-pbr==5.1.1                # via edx-enterprise-data, stevedore
+pbr==5.1.3                # via edx-enterprise-data, stevedore
 pgpy==0.4.3               # via edx-enterprise-data
-pip-tools==3.2.0          # via edx-enterprise-data
-pluggy==0.8.0             # via edx-enterprise-data, pytest, tox
-prompt_toolkit==1.0.15    # via edx-enterprise-data, py2neo
+pip-tools==3.5.0          # via edx-enterprise-data
+pluggy==0.9.0             # via edx-enterprise-data, tox
+prompt-toolkit==2.0.9     # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-py2neo==4.1.3             # via edx-enterprise-data
-py==1.7.0                 # via edx-enterprise-data, pytest, tox
+py2neo==4.2.0             # via edx-enterprise-data
+py==1.8.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.5             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
-pycryptodomex==3.7.2      # via edx-enterprise-data, pyjwkest
+pycryptodomex==3.7.3      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via edx-enterprise-data, py2neo, sphinx
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
@@ -81,28 +79,27 @@ pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.2            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data, urllib3
-pytest==4.0.2             # via edx-enterprise-data, py2neo
-python-dateutil==2.7.5    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
+python-dateutil==2.8.0    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
-pytz==2018.7              # via celery, django, edx-enterprise-data, neotime, vertica-python
+pytz==2018.9              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
+rules==2.0.1              # via edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
-scandir==1.9.0            # via edx-enterprise-data, pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, neotime, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 sphinx==1.2.1
-stevedore==1.30.0         # via edx-enterprise-data, edx-opaque-keys
+stevedore==1.30.1         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.0        # via coreapi
-urllib3[secure]==1.22
+urllib3[secure]==1.24.1
 vertica-python==0.7.3     # via edx-enterprise-data
-virtualenv==16.2.0        # via edx-enterprise-data, tox
+virtualenv==16.4.3        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.2.0
+pip-tools==3.5.0
 six==1.10.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,44 +7,44 @@
 amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 asn1crypto==0.24.0        # via cryptography, edx-enterprise-data
-atomicwrites==1.2.1       # via edx-enterprise-data, pytest
-attrs==18.2.0             # via edx-enterprise-data, pytest
 awscli==1.11.178          # via edx-enterprise-data
-bcrypt==3.1.5             # via edx-enterprise-data, paramiko
+bcrypt==3.1.6             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
 boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
-certifi==2018.11.29       # via edx-enterprise-data, urllib3
-cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
+certifi==2019.3.9         # via edx-enterprise-data, urllib3
+cffi==1.12.2              # via bcrypt, cryptography, edx-enterprise-data, pynacl
 click==7.0                # via edx-enterprise-data, pip-tools, py2neo
 colorama==0.3.7           # via awscli, edx-enterprise-data, py2neo
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl, urllib3
-django-cors-headers==2.4.0
+django-cors-headers==2.5.2
 django-countries==4.5
+django-crum==0.7.3        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
+django-model-utils==3.1.2  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0
 django-storages==1.7.1
-django-waffle==0.15.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.17
+edx-drf-extensions==2.1.0
+edx-enterprise-data==1.0.18
 edx-opaque-keys==0.4.4
+edx-rbac==0.1.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via edx-enterprise-data, pytest
 future==0.17.1            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
 gevent==1.0.2
@@ -54,31 +54,29 @@ idna==2.8                 # via cryptography, edx-enterprise-data, urllib3
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data, urllib3
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
-jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
+jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6
-markupsafe==1.1.0         # via jinja2
-more-itertools==5.0.0     # via edx-enterprise-data, pytest
+markupsafe==1.1.1         # via jinja2
 mysql-python==1.2.5
-neo4j-driver==1.6.2       # via edx-enterprise-data, py2neo
-neotime==1.0.0            # via edx-enterprise-data, neo4j-driver, py2neo
-newrelic==4.8.0.110
+neobolt==1.7.4            # via edx-enterprise-data, py2neo
+neotime==1.7.4            # via edx-enterprise-data, py2neo
+newrelic==4.14.0.115
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
 path.py==8.2.1
-pathlib2==2.3.3           # via edx-enterprise-data, pytest
-pbr==5.1.1                # via edx-enterprise-data, stevedore
+pbr==5.1.3                # via edx-enterprise-data, stevedore
 pgpy==0.4.3               # via edx-enterprise-data
-pip-tools==3.2.0          # via edx-enterprise-data
-pluggy==0.8.0             # via edx-enterprise-data, pytest, tox
-prompt-toolkit==1.0.15    # via edx-enterprise-data, py2neo
+pip-tools==3.5.0          # via edx-enterprise-data
+pluggy==0.9.0             # via edx-enterprise-data, tox
+prompt-toolkit==2.0.9     # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-py2neo==4.1.3             # via edx-enterprise-data
-py==1.7.0                 # via edx-enterprise-data, pytest, tox
+py2neo==4.2.0             # via edx-enterprise-data
+py==1.8.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.5             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
-pycryptodomex==3.7.2      # via edx-enterprise-data, pyjwkest
+pycryptodomex==3.7.3      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via edx-enterprise-data, py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
@@ -86,27 +84,26 @@ pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.2            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data, urllib3
-pytest==4.0.2             # via edx-enterprise-data, py2neo
-python-dateutil==2.7.5    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
+python-dateutil==2.8.0    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
-pytz==2018.7              # via celery, django, edx-enterprise-data, neotime, vertica-python
+pytz==2018.9              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12
 requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
+rules==2.0.1              # via edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
-scandir==1.9.0            # via edx-enterprise-data, pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, neotime, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.30.0         # via edx-enterprise-data, edx-opaque-keys
+stevedore==1.30.1         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.0        # via coreapi
-urllib3[secure]==1.22
+urllib3[secure]==1.24.1
 vertica-python==0.7.3     # via edx-enterprise-data
-virtualenv==16.2.0        # via edx-enterprise-data, tox
+virtualenv==16.4.3        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,92 +8,91 @@ amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 asn1crypto==0.24.0        # via cryptography, edx-enterprise-data
 astroid==1.4.9            # via pylint
-atomicwrites==1.2.1       # via edx-enterprise-data, pytest
-attrs==18.2.0             # via edx-enterprise-data, pytest
 awscli==1.11.178          # via edx-enterprise-data
-backports.functools-lru-cache==1.5  # via pylint
-bcrypt==3.1.5             # via edx-enterprise-data, paramiko
+backports.functools-lru-cache==1.5  # via isort, pylint
+bcrypt==3.1.6             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
 boto==2.42.0
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
-certifi==2018.11.29       # via edx-enterprise-data, urllib3
-cffi==1.11.5              # via bcrypt, cryptography, edx-enterprise-data, pynacl
+certifi==2019.3.9         # via edx-enterprise-data, urllib3
+cffi==1.12.2              # via bcrypt, cryptography, edx-enterprise-data, pynacl
 click==7.0                # via edx-enterprise-data, pip-tools, py2neo
 colorama==0.3.7           # via awscli, edx-enterprise-data, py2neo
-configparser==3.5.1       # via pylint
+configparser==3.7.3       # via pylint
 cookies==2.2.1            # via responses
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 coverage==4.4.1
 cryptography==1.9         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl, urllib3
 ddt==1.1.1
-diff-cover==1.0.6
-django-cors-headers==2.4.0
+diff-cover==1.0.7
+django-cors-headers==2.5.2
 django-countries==4.5
+django-crum==0.7.3        # via edx-enterprise-data, edx-rbac
 django-dynamic-fixture==1.9.5
 django-fernet-fields==0.5  # via edx-enterprise-data
+django-model-utils==3.1.2  # via edx-enterprise-data, edx-rbac
 django-nose==1.4.4
 django-rest-swagger==2.2.0
 django-storages==1.7.1
-django-waffle==0.15.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
+django-waffle==0.15.1     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 django==1.11.15
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 docutils==0.14            # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise-data==1.0.17
+edx-drf-extensions==2.1.0
+edx-enterprise-data==1.0.18
 edx-opaque-keys==0.4.4
+edx-rbac==0.1.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via edx-enterprise-data, mock, pytest
+funcsigs==1.0.2           # via mock
 future==0.17.1            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, isort, s3transfer
 idna==2.8                 # via cryptography, edx-enterprise-data, urllib3
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, edx-enterprise-data, urllib3
-isort==4.3.4              # via pylint
+isort==4.3.15             # via pylint
 itypes==1.1.0             # via coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via coreschema, diff-cover, jinja2-pluralize
-jmespath==0.9.3           # via boto3, botocore, edx-enterprise-data
+jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 lazy-object-proxy==1.3.1  # via astroid
 markdown==2.6.6
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==5.0.0     # via edx-enterprise-data, pytest
-neo4j-driver==1.6.2       # via edx-enterprise-data, py2neo
-neotime==1.0.0            # via edx-enterprise-data, neo4j-driver, py2neo
-newrelic==4.8.0.110       # via edx-django-utils, edx-enterprise-data
+neobolt==1.7.4            # via edx-enterprise-data, py2neo
+neotime==1.7.4            # via edx-enterprise-data, py2neo
+newrelic==4.14.0.115      # via edx-django-utils, edx-enterprise-data
 nose-exclude==0.5.0
 nose-ignore-docstring==0.2
 nose==1.3.7
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
 paramiko==2.4             # via edx-enterprise-data
-pathlib2==2.3.3           # via edx-enterprise-data, pytest
-pbr==5.1.1                # via edx-enterprise-data, mock, stevedore
+pbr==5.1.3                # via edx-enterprise-data, mock, stevedore
 pep257==0.7.0
 pep8==1.7.0
 pgpy==0.4.3               # via edx-enterprise-data
-pip-tools==3.2.0          # via edx-enterprise-data
-pluggy==0.8.0             # via edx-enterprise-data, pytest, tox
-prompt_toolkit==1.0.15    # via edx-enterprise-data, py2neo
+pip-tools==3.5.0          # via edx-enterprise-data
+pluggy==0.9.0             # via edx-enterprise-data, tox
+prompt-toolkit==2.0.9     # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-py2neo==4.1.3             # via edx-enterprise-data
-py==1.7.0                 # via edx-enterprise-data, pytest, tox
+py2neo==4.2.0             # via edx-enterprise-data
+py==1.8.0                 # via edx-enterprise-data, tox
 pyasn1==0.4.5             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
-pycryptodomex==3.7.2      # via edx-enterprise-data, pyjwkest
+pycryptodomex==3.7.3      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via diff-cover, edx-enterprise-data, py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
@@ -102,29 +101,28 @@ pyminizip==0.2.1          # via edx-enterprise-data
 pymongo==3.7.2            # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data, urllib3
-pytest==4.0.2             # via edx-enterprise-data, py2neo
-python-dateutil==2.7.5    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
+python-dateutil==2.8.0    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
-pytz==2018.7
+pytz==2018.9
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.9.1           # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, responses, slumber
 responses==0.5.1
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
+rules==2.0.1              # via edx-enterprise-data
 s3transfer==0.1.13        # via awscli, boto3, edx-enterprise-data
-scandir==1.9.0            # via edx-enterprise-data, pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.16.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, elasticsearch-dsl, mock, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pylint, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, responses, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, mock, neotime, pgpy, pip-tools, prompt-toolkit, pyjwkest, pylint, pynacl, pyopenssl, python-dateutil, python-memcached, responses, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-stevedore==1.30.0         # via edx-enterprise-data, edx-opaque-keys
+stevedore==1.30.1         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
 tqdm==4.11.2
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.0        # via coreapi
-urllib3[secure]==1.22
+urllib3[secure]==1.24.1
 vertica-python==0.7.3     # via edx-enterprise-data
-virtualenv==16.2.0        # via edx-enterprise-data, tox
+virtualenv==16.4.3        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit
 wrapt==1.11.1             # via astroid


### PR DESCRIPTION
[ENT-1602](https://openedx.atlassian.net/browse/ENT-1602)

Updating `edx-enterprise-data` version to incorporate latest changes from [1.0.18](https://github.com/edx/edx-enterprise-data/releases/tag/1.0.18)