### PR TITLE
edx-enterprise-data version bump

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise-data==1.2.1
+edx-enterprise-data==1.2.2
 edx-opaque-keys==0.4.4
 edx-rbac==0.1.10          # via edx-enterprise-data
 edx-rest-api-client==1.9.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise-data==1.2.1
+edx-enterprise-data==1.2.2
 edx-opaque-keys==0.4.4
 edx-rbac==0.1.10          # via edx-enterprise-data
 edx-rest-api-client==1.9.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise-data==1.2.1
+edx-enterprise-data==1.2.2
 edx-opaque-keys==0.4.4
 edx-rbac==0.1.10          # via edx-enterprise-data
 edx-rest-api-client==1.9.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -38,7 +38,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise-data==1.2.1
+edx-enterprise-data==1.2.2
 edx-opaque-keys==0.4.4
 edx-rbac==0.1.10          # via edx-enterprise-data
 edx-rest-api-client==1.9.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise-data==1.2.1
+edx-enterprise-data==1.2.2
 edx-opaque-keys==0.4.4
 edx-rbac==0.1.10          # via edx-enterprise-data
 edx-rest-api-client==1.9.2


### PR DESCRIPTION
Incorporates https://github.com/edx/edx-enterprise-data/pull/119 to turn RBAC waffle switch ON.