### PR TITLE
Fix JWT_ISSUER setting to work outside of docker container.

### DIFF
--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -77,7 +77,7 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', '::1', 'analyticsapi', 'host.docker.i
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
-    'JWT_ISSUER': 'http://edx.devstack.lms:18000/oauth2',
+    'JWT_ISSUER': 'http://localhost:18000/oauth2',
     'JWT_AUDIENCE': None,
     'JWT_VERIFY_AUDIENCE': False,
     'JWT_PUBLIC_SIGNING_JWK_SET': (


### PR DESCRIPTION
This setting was set as if this server was inside a docker container running on the lms' docker network. Until this project is dockerised, I'm setting this to point to `localhost`.