### PR TITLE
Switch edx-analytics-data-api from nose to pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 
 test: clean
 	if [ -e elasticsearch-$(ELASTICSEARCH_VERSION) ]; then curl --silent --head http://localhost:$(ELASTICSEARCH_PORT)/roster_test > /dev/null || make test.run_elasticsearch; fi  # Launch ES if installed and not running
-	coverage run -m pytest \
+	coverage run -m pytest --ignore=analyticsdataserver/settings \
 		$(PACKAGES)
 	export COVERAGE_DIR=$(COVERAGE_DIR) && \
 		coverage html && \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PACKAGES = analyticsdataserver analytics_data_api
 DATABASES = default analytics
 ELASTICSEARCH_VERSION = 1.5.2
 ELASTICSEARCH_PORT = 9223
-TEST_SETTINGS = analyticsdataserver.settings.test
 
 .PHONY: requirements develop clean diff.report view.diff.report quality static
 
@@ -51,8 +50,7 @@ clean:
 
 test: clean
 	if [ -e elasticsearch-$(ELASTICSEARCH_VERSION) ]; then curl --silent --head http://localhost:$(ELASTICSEARCH_PORT)/roster_test > /dev/null || make test.run_elasticsearch; fi  # Launch ES if installed and not running
-	coverage run ./manage.py test --settings=$(TEST_SETTINGS) \
-		--with-ignore-docstrings --exclude-dir=analyticsdataserver/settings \
+	coverage run -m pytest \
 		$(PACKAGES)
 	export COVERAGE_DIR=$(COVERAGE_DIR) && \
 		coverage html && \

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -17,15 +17,9 @@ DATABASES = {
 # Silence elasticsearch during tests
 LOGGING['loggers']['elasticsearch']['handlers'] = ['null']
 
-INSTALLED_APPS += (
-    'django_nose',
-)
-
 LMS_BASE_URL = 'http://lms-host'
 
 LMS_USER_ACCOUNT_BASE_URL = 'http://lms-host'
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # Default elasticsearch port when running locally
 ELASTICSEARCH_LEARNERS_HOST = environ.get("ELASTICSEARCH_LEARNERS_HOST", 'http://localhost:9223/')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = analyticsdataserver.settings.test

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ awscli==1.11.178          # via edx-enterprise-data
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
-boto==2.42.0
+boto==2.42.0              # via -r requirements/base.in
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 certifi==2019.11.28       # via edx-enterprise-data, py2neo, requests
@@ -23,28 +23,28 @@ contextlib2==0.6.0.post1  # via edx-enterprise-data, importlib-metadata
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
-django-cors-headers==3.0.2
-django-countries==4.5
+django-cors-headers==3.0.2  # via -r requirements/base.in
+django-countries==4.5     # via -r requirements/base.in
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
-django-rest-swagger==2.2.0
-django-storages==1.8
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27
-djangorestframework-csv==2.1.0
+django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
-edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.6
-edx-django-utils==2.0.2
-edx-drf-extensions==2.4.5
-edx-enterprise-data==1.3.13
-edx-opaque-keys==2.0.1
+edx-ccx-keys==1.0.0       # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-django-utils==2.0.2   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data
+edx-drf-extensions==2.4.5  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
+edx-enterprise-data==1.3.13  # via -r requirements/base.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
-edx-rest-api-client==1.9.2
-elasticsearch-dsl==0.0.11
+edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
+elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
@@ -56,14 +56,14 @@ itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via coreschema
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
-markdown==2.6.6
+markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via edx-enterprise-data, zipp
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
-ordered-set==2.0.2
+ordered-set==2.0.2        # via -r requirements/base.in
 paramiko==2.4             # via edx-enterprise-data
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata
 pbr==5.4.4                # via edx-enterprise-data, stevedore
@@ -85,7 +85,7 @@ pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
-python-memcached==1.59
+python-memcached==1.59    # via -r requirements/base.in
 pytz==2019.3              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
@@ -101,10 +101,10 @@ six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, e
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
-tqdm==4.11.2
+tqdm==4.11.2              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3
+urllib3==1.24.3           # via -r requirements/base.in, edx-enterprise-data, elasticsearch, py2neo, requests
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ awscli==1.11.178          # via edx-enterprise-data
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
-boto==2.42.0
+boto==2.42.0              # via -r requirements/base.in
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 certifi==2019.11.28       # via edx-enterprise-data, py2neo, requests
@@ -23,28 +23,28 @@ contextlib2==0.6.0.post1  # via edx-enterprise-data, importlib-metadata
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
-django-cors-headers==3.0.2
-django-countries==4.5
+django-cors-headers==3.0.2  # via -r requirements/base.in
+django-countries==4.5     # via -r requirements/base.in
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
-django-rest-swagger==2.2.0
-django-storages==1.8
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27
-djangorestframework-csv==2.1.0
+django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
-edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.6
-edx-django-utils==2.0.2
-edx-drf-extensions==2.4.5
-edx-enterprise-data==1.3.13
-edx-opaque-keys==2.0.1
+edx-ccx-keys==1.0.0       # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-django-utils==2.0.2   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data
+edx-drf-extensions==2.4.5  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
+edx-enterprise-data==1.3.13  # via -r requirements/base.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
-edx-rest-api-client==1.9.2
-elasticsearch-dsl==0.0.11
+edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
+elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
@@ -56,14 +56,14 @@ itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via coreschema
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
-markdown==2.6.6
+markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via edx-enterprise-data, zipp
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
-ordered-set==2.0.2
+ordered-set==2.0.2        # via -r requirements/base.in
 paramiko==2.4             # via edx-enterprise-data
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata
 pbr==5.4.4                # via edx-enterprise-data, stevedore
@@ -85,7 +85,7 @@ pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
-python-memcached==1.59
+python-memcached==1.59    # via -r requirements/base.in
 pytz==2019.3              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
@@ -101,10 +101,10 @@ six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, e
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
-tqdm==4.11.2
+tqdm==4.11.2              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3
+urllib3==1.24.3           # via -r requirements/base.in, edx-enterprise-data, elasticsearch, py2neo, requests
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ awscli==1.11.178          # via edx-enterprise-data
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
-boto==2.42.0
+boto==2.42.0              # via -r requirements/base.in
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 certifi==2019.11.28       # via edx-enterprise-data, py2neo, requests
@@ -23,28 +23,28 @@ contextlib2==0.6.0.post1  # via edx-enterprise-data, importlib-metadata
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
-django-cors-headers==3.0.2
-django-countries==4.5
+django-cors-headers==3.0.2  # via -r requirements/base.in
+django-countries==4.5     # via -r requirements/base.in
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
-django-rest-swagger==2.2.0
-django-storages==1.8
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27
-djangorestframework-csv==2.1.0
+django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data, sphinx
-edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.6
-edx-django-utils==2.0.2
-edx-drf-extensions==2.4.5
-edx-enterprise-data==1.3.13
-edx-opaque-keys==2.0.1
+edx-ccx-keys==1.0.0       # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-django-utils==2.0.2   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data
+edx-drf-extensions==2.4.5  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
+edx-enterprise-data==1.3.13  # via -r requirements/base.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
-edx-rest-api-client==1.9.2
-elasticsearch-dsl==0.0.11
+edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
+elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
@@ -53,17 +53,17 @@ idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data
 itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via coreschema, sphinx
+jinja2==2.11.1            # via sphinx
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
-markdown==2.6.6
+markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via edx-enterprise-data, zipp
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
-ordered-set==2.0.2
+ordered-set==2.0.2        # via -r requirements/base.in
 paramiko==2.4             # via edx-enterprise-data
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata
 pbr==5.4.4                # via edx-enterprise-data, stevedore
@@ -85,7 +85,7 @@ pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
-python-memcached==1.59
+python-memcached==1.59    # via -r requirements/base.in
 pytz==2019.3              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
@@ -99,13 +99,13 @@ simplejson==3.17.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
 six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
-sphinx==1.2.1
+sphinx==1.2.1             # via -r requirements/doc.in
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
-tqdm==4.11.2
+tqdm==4.11.2              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3
+urllib3==1.24.3           # via -r requirements/base.in, edx-enterprise-data, elasticsearch, py2neo, requests
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.4.1
+pip-tools==4.5.1
 six==1.10.0

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.5.1
-six==1.10.0
+pip-tools==4.5.1          # via -r requirements/pip_tools.in
+six==1.10.0               # via -r requirements/pip_tools.in, pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,7 +37,7 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.5
+edx-django-release-util==0.3.6
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-enterprise-data==1.3.13
@@ -56,7 +56,7 @@ idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data
 itypes==1.1.0             # via coreapi
-jinja2==2.11.0            # via coreschema
+jinja2==2.11.1            # via coreschema
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 markdown==2.6.6

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,7 +10,7 @@ awscli==1.11.178          # via edx-enterprise-data
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
-boto==2.42.0
+boto==2.42.0              # via -r requirements/base.in
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 certifi==2019.11.28       # via edx-enterprise-data, py2neo, requests
@@ -23,35 +23,35 @@ contextlib2==0.6.0.post1  # via edx-enterprise-data, importlib-metadata
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
-django-cors-headers==3.0.2
-django-countries==4.5
+django-cors-headers==3.0.2  # via -r requirements/base.in
+django-countries==4.5     # via -r requirements/base.in
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
-django-rest-swagger==2.2.0
-django-storages==1.8
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27
-djangorestframework-csv==2.1.0
+django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
-edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.6
-edx-django-utils==2.0.2
-edx-drf-extensions==2.4.5
-edx-enterprise-data==1.3.13
-edx-opaque-keys==2.0.1
+edx-ccx-keys==1.0.0       # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-django-utils==2.0.2   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data
+edx-drf-extensions==2.4.5  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
+edx-enterprise-data==1.3.13  # via -r requirements/base.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
-edx-rest-api-client==1.9.2
-elasticsearch-dsl==0.0.11
+edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
+elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, s3transfer
-gevent==1.4.0
+gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
-gunicorn==19.6.0
+gunicorn==19.6.0          # via -r requirements/production.in
 idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data
@@ -59,17 +59,17 @@ itypes==1.1.0             # via coreapi
 jinja2==2.11.1            # via coreschema
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
-markdown==2.6.6
+markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0     # via edx-enterprise-data, zipp
-mysql-python==1.2.5
+mysql-python==1.2.5       # via -r requirements/production.in
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
-newrelic==5.4.1.134
+newrelic==5.4.1.134       # via -r requirements/production.in, edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
-ordered-set==2.0.2
+ordered-set==2.0.2        # via -r requirements/base.in
 paramiko==2.4             # via edx-enterprise-data
-path.py==8.2.1
+path.py==8.2.1            # via -r requirements/production.in
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata
 pbr==5.4.4                # via edx-enterprise-data, stevedore
 pgpy==0.5.2               # via edx-enterprise-data
@@ -90,9 +90,9 @@ pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
-python-memcached==1.59
+python-memcached==1.59    # via -r requirements/base.in
 pytz==2019.3              # via celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
-pyyaml==3.12
+pyyaml==3.12              # via -r requirements/production.in, awscli, edx-django-release-util, edx-enterprise-data
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
@@ -106,10 +106,10 @@ six==1.10.0               # via bcrypt, cryptography, djangorestframework-csv, e
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
-tqdm==4.11.2
+tqdm==4.11.2              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3
+urllib3==1.24.3           # via -r requirements/base.in, edx-enterprise-data, elasticsearch, py2neo, requests
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -14,5 +14,7 @@ nose==1.3.7
 pep257==0.7.0
 pep8==1.7.0
 pylint==1.6.5
+pytest-cov
+pytest-django
 pytz
 responses==0.5.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,11 +6,7 @@ coverage==4.4.1
 ddt==1.1.1
 diff-cover >= 0.9.9
 django-dynamic-fixture==1.9.5
-django-nose==1.4.4
 mock==2.0.0
-nose-exclude==0.5.0
-nose-ignore-docstring==0.2
-nose==1.3.7
 pep257==0.7.0
 pep8==1.7.0
 pylint==1.6.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ backports.functools-lru-cache==1.6.1  # via isort, pylint
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
 billiard==3.3.0.23        # via celery, edx-enterprise-data
 boto3==1.4.7              # via edx-enterprise-data
-boto==2.42.0
+boto==2.42.0              # via -r requirements/base.in
 botocore==1.7.36          # via awscli, boto3, edx-enterprise-data, s3transfer
 celery==3.1.18            # via edx-enterprise-data
 certifi==2019.11.28       # via edx-enterprise-data, py2neo, requests
@@ -27,34 +27,33 @@ contextlib2==0.6.0.post1  # via edx-enterprise-data, importlib-metadata
 cookies==2.2.1            # via responses
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-coverage==4.4.1
+coverage==4.4.1           # via -r requirements/test.in, pytest-cov
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
-ddt==1.1.1
-diff-cover==2.6.0
-django-cors-headers==3.0.2
-django-countries==4.5
+ddt==1.1.1                # via -r requirements/test.in
+diff-cover==2.6.0         # via -r requirements/test.in
+django-cors-headers==3.0.2  # via -r requirements/base.in
+django-countries==4.5     # via -r requirements/base.in
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
-django-dynamic-fixture==1.9.5
+django-dynamic-fixture==1.9.5  # via -r requirements/test.in
 django-fernet-fields==0.5  # via edx-enterprise-data
 django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
-django-nose==1.4.4
-django-rest-swagger==2.2.0
-django-storages==1.8
+django-rest-swagger==2.2.0  # via -r requirements/base.in
+django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27
-djangorestframework-csv==2.1.0
+django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
-edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.6
-edx-django-utils==2.0.2
-edx-drf-extensions==2.4.5
-edx-enterprise-data==1.3.13
-edx-opaque-keys==2.0.1
+edx-ccx-keys==1.0.0       # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-django-utils==2.0.2   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data
+edx-drf-extensions==2.4.5  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
+edx-enterprise-data==1.3.13  # via -r requirements/base.in
+edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
-edx-rest-api-client==1.9.2
-elasticsearch-dsl==0.0.11
+edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
+elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 funcsigs==1.0.2           # via mock, pytest
@@ -71,25 +70,22 @@ jinja2==2.11.1            # via coreschema, diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 lazy-object-proxy==1.4.3  # via astroid
-markdown==2.6.6
+markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==2.0.0
+mock==2.0.0               # via -r requirements/test.in, responses
 more-itertools==5.0.0     # via edx-enterprise-data, pytest, zipp
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
-nose-exclude==0.5.0
-nose-ignore-docstring==0.2
-nose==1.3.7
 openapi-codec==1.3.2      # via django-rest-swagger
-ordered-set==2.0.2
+ordered-set==2.0.2        # via -r requirements/base.in
 packaging==20.1           # via pytest
 paramiko==2.4             # via edx-enterprise-data
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata, pytest, pytest-django
 pbr==5.4.4                # via edx-enterprise-data, mock, stevedore
-pep257==0.7.0
-pep8==1.7.0
+pep257==0.7.0             # via -r requirements/test.in
+pep8==1.7.0               # via -r requirements/test.in
 pgpy==0.5.2               # via edx-enterprise-data
 pip-tools==4.3.0          # via edx-enterprise-data
 pluggy==0.13.1            # via diff-cover, edx-enterprise-data, pytest, tox
@@ -103,21 +99,21 @@ pycryptodomex==3.9.4      # via edx-enterprise-data, pyjwkest
 pygments==2.3.1           # via diff-cover, edx-enterprise-data, py2neo
 pyjwkest==1.3.2           # via edx-drf-extensions, edx-enterprise-data
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-enterprise-data, edx-rest-api-client
-pylint==1.6.5
+pylint==1.6.5             # via -r requirements/test.in
 pyminizip==0.2.4          # via edx-enterprise-data
 pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
 pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1
-pytest-django==3.8.0
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
 pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
-python-memcached==1.59
-pytz==2019.3
+python-memcached==1.59    # via -r requirements/base.in
+pytz==2019.3              # via -r requirements/test.in, celery, django, edx-enterprise-data, neotime, py2neo, vertica-python
 pyyaml==3.12              # via awscli, edx-django-release-util, edx-enterprise-data
 requests==2.22.0          # via coreapi, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client, pyjwkest, responses, slumber
-responses==0.5.1
+responses==0.5.1          # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions, edx-enterprise-data
 rsa==3.4.2                # via awscli, edx-enterprise-data
 rules==2.1                # via edx-enterprise-data
@@ -130,10 +126,10 @@ six==1.10.0               # via astroid, bcrypt, cryptography, diff-cover, djang
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
-tqdm==4.11.2
+tqdm==4.11.2              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv, edx-enterprise-data
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3
+urllib3==1.24.3           # via -r requirements/base.in, edx-enterprise-data, elasticsearch, py2neo, requests
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
 wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,6 +7,8 @@
 amqp==1.4.9               # via edx-enterprise-data, kombu
 anyjson==0.3.3            # via edx-enterprise-data, kombu
 astroid==1.4.9            # via pylint
+atomicwrites==1.3.0       # via pytest
+attrs==19.3.0             # via pytest
 awscli==1.11.178          # via edx-enterprise-data
 backports.functools-lru-cache==1.6.1  # via isort, pylint
 bcrypt==3.1.7             # via edx-enterprise-data, paramiko
@@ -28,7 +30,7 @@ coreschema==0.0.4         # via coreapi
 coverage==4.4.1
 cryptography==2.8         # via django-fernet-fields, edx-enterprise-data, paramiko, pgpy, pyopenssl
 ddt==1.1.1
-diff-cover==2.5.2
+diff-cover==2.6.0
 django-cors-headers==3.0.2
 django-countries==4.5
 django-crum==0.7.5        # via edx-enterprise-data, edx-rbac
@@ -45,7 +47,7 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4
 docutils==0.15.2          # via awscli, botocore, edx-enterprise-data
 edx-ccx-keys==1.0.0
-edx-django-release-util==0.3.5
+edx-django-release-util==0.3.6
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-enterprise-data==1.3.13
@@ -55,17 +57,17 @@ edx-rest-api-client==1.9.2
 elasticsearch-dsl==0.0.11
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2           # via mock, pytest
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
 futures==3.2.0            # via edx-enterprise-data, isort, s3transfer
 idna==2.8                 # via edx-enterprise-data, requests
-importlib-metadata==1.3.0  # via edx-enterprise-data, inflect, pluggy
+importlib-metadata==1.3.0  # via edx-enterprise-data, inflect, pluggy, pytest
 inflect==3.0.2            # via jinja2-pluralize
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data
 isort==4.3.21             # via pylint
 itypes==1.1.0             # via coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.0            # via coreschema, diff-cover, jinja2-pluralize
+jinja2==2.11.1            # via coreschema, diff-cover, jinja2-pluralize
 jmespath==0.9.4           # via boto3, botocore, edx-enterprise-data
 kombu==3.0.37             # via celery, edx-enterprise-data
 lazy-object-proxy==1.4.3  # via astroid
@@ -73,7 +75,7 @@ markdown==2.6.6
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==5.0.0     # via edx-enterprise-data, zipp
+more-itertools==5.0.0     # via edx-enterprise-data, pytest, zipp
 neobolt==1.7.16           # via edx-enterprise-data, py2neo
 neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
@@ -82,18 +84,19 @@ nose-ignore-docstring==0.2
 nose==1.3.7
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2
+packaging==20.1           # via pytest
 paramiko==2.4             # via edx-enterprise-data
-pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata
+pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata, pytest, pytest-django
 pbr==5.4.4                # via edx-enterprise-data, mock, stevedore
 pep257==0.7.0
 pep8==1.7.0
 pgpy==0.5.2               # via edx-enterprise-data
 pip-tools==4.3.0          # via edx-enterprise-data
-pluggy==0.13.1            # via diff-cover, edx-enterprise-data, tox
+pluggy==0.13.1            # via diff-cover, edx-enterprise-data, pytest, tox
 prompt-toolkit==2.0.10    # via edx-enterprise-data, py2neo
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
 py2neo==4.3.0             # via edx-enterprise-data
-py==1.8.1                 # via edx-enterprise-data, tox
+py==1.8.1                 # via edx-enterprise-data, pytest, tox
 pyasn1==0.4.8             # via edx-enterprise-data, paramiko, pgpy, rsa
 pycparser==2.19           # via cffi, edx-enterprise-data
 pycryptodomex==3.9.4      # via edx-enterprise-data, pyjwkest
@@ -105,6 +108,10 @@ pyminizip==0.2.4          # via edx-enterprise-data
 pymongo==3.10.0           # via edx-enterprise-data, edx-opaque-keys
 pynacl==1.3.0             # via edx-enterprise-data, paramiko
 pyopenssl==17.4.0         # via edx-enterprise-data
+pyparsing==2.4.6          # via packaging
+pytest-cov==2.8.1
+pytest-django==3.8.0
+pytest==4.6.9             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, edx-enterprise-data, elasticsearch-dsl, vertica-python
 python-memcached==1.59
 pytz==2019.3
@@ -119,7 +126,7 @@ scandir==1.10.0           # via edx-enterprise-data, pathlib2
 semantic-version==2.8.4   # via edx-drf-extensions, edx-enterprise-data
 simplejson==3.17.0        # via django-rest-swagger
 singledispatch==3.4.0.3   # via edx-enterprise-data, pgpy
-six==1.10.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, mock, more-itertools, neotime, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pylint, pynacl, pyopenssl, python-dateutil, python-memcached, responses, singledispatch, stevedore, tox, vertica-python
+six==1.10.0               # via astroid, bcrypt, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, mock, more-itertools, neotime, packaging, pathlib2, pgpy, pip-tools, prompt-toolkit, pyjwkest, pylint, pynacl, pyopenssl, pytest, python-dateutil, python-memcached, responses, singledispatch, stevedore, tox, vertica-python
 slumber==0.7.1            # via edx-enterprise-data, edx-rest-api-client
 stevedore==1.31.0         # via edx-enterprise-data, edx-opaque-keys
 tox==3.0.0                # via edx-enterprise-data
@@ -129,6 +136,6 @@ uritemplate==3.0.1        # via coreapi
 urllib3==1.24.3
 vertica-python==0.7.3     # via edx-enterprise-data
 virtualenv==16.7.9        # via edx-enterprise-data, tox
-wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit
-wrapt==1.11.2             # via astroid
+wcwidth==0.1.7            # via edx-enterprise-data, prompt-toolkit, pytest
+wrapt==1.12.0             # via astroid
 zipp==0.6.0               # via edx-enterprise-data, importlib-metadata


### PR DESCRIPTION
Move nose tests to pytest. https://openedx.atlassian.net/projects/BOM/issues/BOM-1359

### Packages removed
nose-exclude==0.5.0	
nose-ignore-docstring==0.2	
nose==1.3.7
django-nose==1.4.4

### New packages
packaging==20.1           # via pytest
pyparsing==2.4.6          # via packaging
pytest-cov==2.8.1         # via -r requirements/test.in
pytest-django==3.8.0      # via -r requirements/test.in
pytest==4.6.9             # via pytest-cov, pytest-django

### Constraints changed
-

### Reviewers
- [ ] @andrey-canon
- [x] Is this ready for edX's review?
- [ ] @jmbowman 

### Warnings
ERROR: edx-enterprise-data 1.3.13 has requirement pip-tools==4.3.0, but you'll have pip-tools 4.5.1 which is incompatible.

I think that we need to remove pip-tools from edx-enterprise-data base.txt requirements since that is not an actual requirement for the usage of that package. See https://github.com/edx/edx-enterprise-data/pull/165

### Post-review
- [ ] Rebase and squash commits
