### PR TITLE
[BD] Modernize analytics_data_api/v0

### DIFF
--- a/analytics_data_api/v0/apps.py
+++ b/analytics_data_api/v0/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.apps import AppConfig
 from django.conf import settings
 from elasticsearch_dsl import connections

--- a/analytics_data_api/v0/connections.py
+++ b/analytics_data_api/v0/connections.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+
 import json
 import time
 
+import six
 from boto.connection import AWSAuthConnection
 from elasticsearch import Connection
 
@@ -37,7 +40,7 @@ class BotoHttpConnection(Connection):
         and the default is 70 seconds.
         See: https://github.com/boto/boto/blob/develop/boto/connection.py#L533
         """
-        if not isinstance(body, basestring):
+        if not isinstance(body, six.string_types):
             body = json.dumps(body)
         start = time.time()
         response = self.connection.make_request(method, url, params=params, data=body)

--- a/analytics_data_api/v0/exceptions.py
+++ b/analytics_data_api/v0/exceptions.py
@@ -1,12 +1,14 @@
+from __future__ import absolute_import
+
 import abc
 
+import six
 
-class BaseError(Exception):
+
+class BaseError(six.with_metaclass(abc.ABCMeta, Exception)):
     """
     Base error.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     message = None
 

--- a/analytics_data_api/v0/middleware.py
+++ b/analytics_data_api/v0/middleware.py
@@ -7,9 +7,14 @@ from django.http.response import JsonResponse
 from rest_framework import status
 
 from analytics_data_api.v0.exceptions import (
-    CannotCreateReportDownloadLinkError, CourseKeyMalformedError,
-    CourseNotSpecifiedError, LearnerEngagementTimelineNotFoundError,
-    LearnerNotFoundError, ParameterValueError, ReportFileNotFoundError)
+    CannotCreateReportDownloadLinkError,
+    CourseKeyMalformedError,
+    CourseNotSpecifiedError,
+    LearnerEngagementTimelineNotFoundError,
+    LearnerNotFoundError,
+    ParameterValueError,
+    ReportFileNotFoundError
+)
 
 
 class BaseProcessErrorMiddleware(six.with_metaclass(abc.ABCMeta, object)):

--- a/analytics_data_api/v0/middleware.py
+++ b/analytics_data_api/v0/middleware.py
@@ -13,7 +13,7 @@ from analytics_data_api.v0.exceptions import (
     LearnerEngagementTimelineNotFoundError,
     LearnerNotFoundError,
     ParameterValueError,
-    ReportFileNotFoundError
+    ReportFileNotFoundError,
 )
 
 

--- a/analytics_data_api/v0/middleware.py
+++ b/analytics_data_api/v0/middleware.py
@@ -1,24 +1,21 @@
+from __future__ import absolute_import
+
 import abc
+
+import six
 from django.http.response import JsonResponse
 from rest_framework import status
 
 from analytics_data_api.v0.exceptions import (
-    CourseKeyMalformedError,
-    CourseNotSpecifiedError,
-    LearnerEngagementTimelineNotFoundError,
-    LearnerNotFoundError,
-    ParameterValueError,
-    ReportFileNotFoundError,
-    CannotCreateReportDownloadLinkError,
-)
+    CannotCreateReportDownloadLinkError, CourseKeyMalformedError,
+    CourseNotSpecifiedError, LearnerEngagementTimelineNotFoundError,
+    LearnerNotFoundError, ParameterValueError, ReportFileNotFoundError)
 
 
-class BaseProcessErrorMiddleware(object):
+class BaseProcessErrorMiddleware(six.with_metaclass(abc.ABCMeta, object)):
     """
     Base error.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def error(self):

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -8,8 +8,8 @@ from django.db import models
 from django.db.models import Case, Count, IntegerField, Max, Sum, When
 from django.utils.timezone import now
 # some fields (e.g. Float, Integer) are dynamic and your IDE may highlight them as unavailable
-from elasticsearch_dsl import (Date,  # pylint: disable=no-name-in-module
-                               DocType, Float, Integer, Q, String)
+from elasticsearch_dsl import Date  # pylint: disable=no-name-in-module
+from elasticsearch_dsl import DocType, Float, Integer, Q, String
 
 from analytics_data_api.constants import country, genders, learner
 from analytics_data_api.constants.engagement_types import EngagementType

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -1,12 +1,15 @@
+from __future__ import absolute_import
+
 import datetime
 from itertools import groupby
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Count, Sum, When, IntegerField, Case, Max
+from django.db.models import Case, Count, IntegerField, Max, Sum, When
 from django.utils.timezone import now
 # some fields (e.g. Float, Integer) are dynamic and your IDE may highlight them as unavailable
-from elasticsearch_dsl import Date, DocType, Float, Integer, Q, String  # pylint: disable=no-name-in-module
+from elasticsearch_dsl import (Date,  # pylint: disable=no-name-in-module
+                               DocType, Float, Integer, Q, String)
 
 from analytics_data_api.constants import country, genders, learner
 from analytics_data_api.constants.engagement_types import EngagementType

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -8,8 +8,7 @@ from django.db import models
 from django.db.models import Case, Count, IntegerField, Max, Sum, When
 from django.utils.timezone import now
 # some fields (e.g. Float, Integer) are dynamic and your IDE may highlight them as unavailable
-from elasticsearch_dsl import Date  # pylint: disable=no-name-in-module
-from elasticsearch_dsl import DocType, Float, Integer, Q, String
+from elasticsearch_dsl import Date, DocType, Float, Integer, Q, String  # pylint: disable=no-name-in-module
 
 from analytics_data_api.constants import country, genders, learner
 from analytics_data_api.constants.engagement_types import EngagementType

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -1,15 +1,15 @@
+from __future__ import absolute_import
+
 from collections import OrderedDict
-from urlparse import urljoin
+
+import six
 from django.conf import settings
 from rest_framework import pagination, serializers
 from rest_framework.response import Response
+from six.moves.urllib.parse import urljoin
 
-from analytics_data_api.constants import (
-    engagement_events,
-    enrollment_modes,
-)
+from analytics_data_api.constants import engagement_events, enrollment_modes
 from analytics_data_api.v0 import models
-
 
 # Below are the enrollment modes supported by this API.
 ENROLLMENT_MODES = [enrollment_modes.AUDIT, enrollment_modes.CREDIT, enrollment_modes.HONOR,
@@ -369,7 +369,7 @@ class LearnerSerializer(serializers.Serializer):
         # using hasattr() instead because DocType.get() is overloaded and makes a request
         if hasattr(obj, 'segments'):
             # json parsing will fail unless in unicode
-            return [unicode(segment) for segment in obj.segments]
+            return [six.text_type(segment) for segment in obj.segments]
         else:
             return []
 

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -6,9 +6,12 @@ import six
 from django.conf import settings
 from rest_framework import pagination, serializers
 from rest_framework.response import Response
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
 
-from analytics_data_api.constants import engagement_events, enrollment_modes
+from analytics_data_api.constants import (
+    engagement_events,
+    enrollment_modes
+)
 from analytics_data_api.v0 import models
 
 # Below are the enrollment modes supported by this API.

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -8,10 +8,7 @@ from rest_framework import pagination, serializers
 from rest_framework.response import Response
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error,ungrouped-imports
 
-from analytics_data_api.constants import (
-    engagement_events,
-    enrollment_modes
-)
+from analytics_data_api.constants import engagement_events, enrollment_modes
 from analytics_data_api.v0 import models
 
 # Below are the enrollment modes supported by this API.

--- a/analytics_data_api/v0/tests/test_connections.py
+++ b/analytics_data_api/v0/tests/test_connections.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import socket
 
 from django.test import TestCase

--- a/analytics_data_api/v0/tests/test_connections.py
+++ b/analytics_data_api/v0/tests/test_connections.py
@@ -4,9 +4,9 @@ import socket
 
 from django.test import TestCase
 from elasticsearch.exceptions import ElasticsearchException
-from mock import patch
 
 from analytics_data_api.v0.connections import BotoHttpConnection, ESConnection
+from mock import patch
 
 
 class ESConnectionTests(TestCase):

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 from django.test import TestCase
-from django_dynamic_fixture import G
 
 from analytics_data_api.constants.country import UNKNOWN_COUNTRY, get_country
 from analytics_data_api.v0 import models
+from django_dynamic_fixture import G
 
 
 class CourseEnrollmentByCountryTests(TestCase):

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 from django.test import TestCase
 from django_dynamic_fixture import G
 
-from analytics_data_api.v0 import models
 from analytics_data_api.constants.country import UNKNOWN_COUNTRY, get_country
+from analytics_data_api.v0 import models
 
 
 class CourseEnrollmentByCountryTests(TestCase):

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import
+
 from datetime import date
+
 from django.test import TestCase
 from django_dynamic_fixture import G
 
-from analytics_data_api.v0 import models as api_models, serializers as api_serializers
+from analytics_data_api.v0 import models as api_models
+from analytics_data_api.v0 import serializers as api_serializers
 
 
 class TestSerializer(api_serializers.CourseEnrollmentDailySerializer, api_serializers.DynamicFieldsModelSerializer):
@@ -14,14 +18,14 @@ class DynamicFieldsModelSerializerTests(TestCase):
         now = date.today()
         instance = G(api_models.CourseEnrollmentDaily, course_id='1', count=1, date=now)
         serialized = TestSerializer(instance)
-        self.assertListEqual(serialized.data.keys(), ['course_id', 'date', 'count', 'created'])
+        self.assertListEqual(list(serialized.data.keys()), ['course_id', 'date', 'count', 'created'])
 
         instance = G(api_models.CourseEnrollmentDaily, course_id='2', count=1, date=now)
         serialized = TestSerializer(instance, fields=('course_id',))
-        self.assertListEqual(serialized.data.keys(), ['course_id'])
+        self.assertListEqual(list(serialized.data.keys()), ['course_id'])
 
     def test_exclude(self):
         now = date.today()
         instance = G(api_models.CourseEnrollmentDaily, course_id='3', count=1, date=now)
         serialized = TestSerializer(instance, exclude=('course_id',))
-        self.assertListEqual(serialized.data.keys(), ['date', 'count', 'created'])
+        self.assertListEqual(list(serialized.data.keys()), ['date', 'count', 'created'])

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 from datetime import date
 
 from django.test import TestCase
-from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models as api_models
 from analytics_data_api.v0 import serializers as api_serializers
+from django_dynamic_fixture import G
 
 
 class TestSerializer(api_serializers.CourseEnrollmentDailySerializer, api_serializers.DynamicFieldsModelSerializer):

--- a/analytics_data_api/v0/tests/test_urls.py
+++ b/analytics_data_api/v0/tests/test_urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 

--- a/analytics_data_api/v0/tests/utils.py
+++ b/analytics_data_api/v0/tests/utils.py
@@ -4,9 +4,9 @@ import collections
 import datetime
 
 import pytz
-from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models
+from django_dynamic_fixture import G
 
 
 def flatten(dictionary, parent_key='', sep='.'):

--- a/analytics_data_api/v0/tests/utils.py
+++ b/analytics_data_api/v0/tests/utils.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
+
 import collections
 import datetime
-import pytz
 
+import pytz
 from django_dynamic_fixture import G
+
 from analytics_data_api.v0 import models
 
 
@@ -16,7 +19,7 @@ def flatten(dictionary, parent_key='', sep='.'):
     for key, value in dictionary.items():
         new_key = parent_key + sep + key if parent_key else key
         if isinstance(value, collections.MutableMapping):
-            items.extend(flatten(value, new_key).items())
+            items.extend(list(flatten(value, new_key).items()))
         else:
             items.append((new_key, value))
     return dict(items)

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -8,8 +8,8 @@ from collections import OrderedDict
 import six
 from django_dynamic_fixture import G
 from rest_framework import status
-from six.moves import map, zip
-from six.moves.urllib.parse import urlencode
+from six.moves import map, zip  # pylint: disable=ungrouped-imports
+from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from analytics_data_api.v0.tests.utils import flatten
 

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -1,11 +1,15 @@
+from __future__ import absolute_import
+
 import csv
 import json
 import StringIO
 from collections import OrderedDict
-from urllib import urlencode
 
+import six
 from django_dynamic_fixture import G
 from rest_framework import status
+from six.moves import map, zip
+from six.moves.urllib.parse import urlencode
 
 from analytics_data_api.v0.tests.utils import flatten
 
@@ -58,12 +62,12 @@ class VerifyCsvResponseMixin(object):
 
         # Validate other response headers
         if expected_headers:
-            for header_name, header_content in expected_headers.iteritems():
+            for header_name, header_content in six.iteritems(expected_headers):
                 self.assertEquals(response.get(header_name), header_content)
 
         # Validate the content data
         if expected_data:
-            data = map(flatten, expected_data)
+            data = list(map(flatten, expected_data))
 
             # The CSV renderer sorts the headers alphabetically
             fieldnames = sorted(data[0].keys())

--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -6,12 +6,12 @@ import StringIO
 from collections import OrderedDict
 
 import six
-from django_dynamic_fixture import G
 from rest_framework import status
 from six.moves import map, zip  # pylint: disable=ungrouped-imports
 from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from analytics_data_api.v0.tests.utils import flatten
+from django_dynamic_fixture import G
 
 
 class CourseSamples(object):

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -1,14 +1,17 @@
+from __future__ import absolute_import
+
 import datetime
 
 import ddt
-from django_dynamic_fixture import G
 import pytz
-
 from django.conf import settings
+from django_dynamic_fixture import G
 
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin, APIListViewTestMixin
+from analytics_data_api.v0.tests.views import (APIListViewTestMixin,
+                                               CourseSamples,
+                                               VerifyCourseIdMixin)
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -2,19 +2,15 @@ from __future__ import absolute_import
 
 import datetime
 
-import ddt
 import pytz
 from django.conf import settings
-from django_dynamic_fixture import G
 
+import ddt
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import (
-    APIListViewTestMixin,
-    CourseSamples,
-    VerifyCourseIdMixin
-)
+from analytics_data_api.v0.tests.views import APIListViewTestMixin, CourseSamples, VerifyCourseIdMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -9,9 +9,11 @@ from django_dynamic_fixture import G
 
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import (APIListViewTestMixin,
-                                               CourseSamples,
-                                               VerifyCourseIdMixin)
+from analytics_data_api.v0.tests.views import (
+    APIListViewTestMixin,
+    CourseSamples,
+    VerifyCourseIdMixin
+)
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -9,7 +9,6 @@ import datetime
 from collections import OrderedDict
 from itertools import groupby
 
-import ddt
 import pytz
 import six
 import six.moves.urllib.error  # pylint: disable=import-error
@@ -17,11 +16,10 @@ import six.moves.urllib.parse  # pylint: disable=import-error
 import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.utils import timezone
-from django_dynamic_fixture import G
-from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey
 from six.moves import range  # pylint: disable=ungrouped-imports
 
+import ddt
 from analytics_data_api.constants import country, enrollment_modes, genders
 from analytics_data_api.constants.country import get_country
 from analytics_data_api.constants.engagement_events import (
@@ -38,6 +36,8 @@ from analytics_data_api.v0 import models
 from analytics_data_api.v0.tests.utils import create_engagement
 from analytics_data_api.v0.tests.views import CourseSamples, VerifyCsvResponseMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
+from mock import Mock, patch
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -29,7 +29,7 @@ from analytics_data_api.constants.engagement_events import (
     DISCUSSION,
     PROBLEM,
     VIDEO,
-    VIEWED
+    VIEWED,
 )
 from analytics_data_api.utils import get_filename_safe_course_id
 from analytics_data_api.v0 import models

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -11,9 +11,7 @@ from itertools import groupby
 
 import pytz
 import six
-import six.moves.urllib.error  # pylint: disable=import-error
 import six.moves.urllib.parse  # pylint: disable=import-error
-import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.utils import timezone
 from opaque_keys.edx.keys import CourseKey

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -12,29 +12,31 @@ from itertools import groupby
 import ddt
 import pytz
 import six
-import six.moves.urllib.error
-import six.moves.urllib.parse
-import six.moves.urllib.request
+import six.moves.urllib.error  # pylint: disable=import-error
+import six.moves.urllib.parse  # pylint: disable=import-error
+import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.utils import timezone
 from django_dynamic_fixture import G
 from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey
-from six.moves import range
+from six.moves import range  # pylint: disable=ungrouped-imports
 
 from analytics_data_api.constants import country, enrollment_modes, genders
 from analytics_data_api.constants.country import get_country
-from analytics_data_api.constants.engagement_events import (ATTEMPTED,
-                                                            COMPLETED,
-                                                            CONTRIBUTED,
-                                                            DISCUSSION,
-                                                            PROBLEM, VIDEO,
-                                                            VIEWED)
+from analytics_data_api.constants.engagement_events import (
+    ATTEMPTED,
+    COMPLETED,
+    CONTRIBUTED,
+    DISCUSSION,
+    PROBLEM,
+    VIDEO,
+    VIEWED
+)
 from analytics_data_api.utils import get_filename_safe_course_id
 from analytics_data_api.v0 import models
 from analytics_data_api.v0.tests.utils import create_engagement
-from analytics_data_api.v0.tests.views import (CourseSamples,
-                                               VerifyCsvResponseMixin)
+from analytics_data_api.v0.tests.views import CourseSamples, VerifyCsvResponseMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 
@@ -291,8 +293,10 @@ class CourseEnrollmentByBirthYearViewTests(CourseEnrollmentViewTestCaseMixin, Te
 
     def format_as_response(self, *args):
         return [
-            {'course_id': six.text_type(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
-             'birth_year': ce.birth_year, 'created': ce.created.strftime(settings.DATETIME_FORMAT)} for ce in args]
+            {'course_id': six.text_type(ce.course_id), 'count': ce.count,
+             'date': ce.date.strftime(settings.DATE_FORMAT), 'birth_year': ce.birth_year,
+             'created': ce.created.strftime(settings.DATETIME_FORMAT)} for ce in args
+        ]
 
     @ddt.data(*CourseSamples.course_ids)
     def test_get(self, course_id):
@@ -323,9 +327,10 @@ class CourseEnrollmentByEducationViewTests(CourseEnrollmentViewTestCaseMixin, Te
 
     def format_as_response(self, *args):
         return [
-            {'course_id': six.text_type(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
-             'education_level': ce.education_level, 'created': ce.created.strftime(settings.DATETIME_FORMAT)} for
-            ce in args]
+            {'course_id': six.text_type(ce.course_id), 'count': ce.count,
+             'date': ce.date.strftime(settings.DATE_FORMAT), 'education_level': ce.education_level,
+             'created': ce.created.strftime(settings.DATETIME_FORMAT)} for ce in args
+        ]
 
 
 @ddt.ddt
@@ -402,9 +407,10 @@ class CourseEnrollmentViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithA
 
     def format_as_response(self, *args):
         return [
-            {'course_id': six.text_type(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
-             'created': ce.created.strftime(settings.DATETIME_FORMAT)}
-            for ce in args]
+            {'course_id': six.text_type(ce.course_id), 'count': ce.count,
+             'date': ce.date.strftime(settings.DATE_FORMAT), 'created': ce.created.strftime(settings.DATETIME_FORMAT)}
+            for ce in args
+        ]
 
 
 @ddt.ddt
@@ -489,10 +495,11 @@ class CourseEnrollmentByLocationViewTests(CourseEnrollmentViewTestCaseMixin, Tes
 
         response = [unknown]
         response += [
-            {'course_id': six.text_type(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
+            {'course_id': six.text_type(ce.course_id), 'count': ce.count,
+             'date': ce.date.strftime(settings.DATE_FORMAT),
              'country': {'alpha2': ce.country.alpha2, 'alpha3': ce.country.alpha3, 'name': ce.country.name},
-             'created': ce.created.strftime(settings.DATETIME_FORMAT)} for ce in
-            args]
+             'created': ce.created.strftime(settings.DATETIME_FORMAT)} for ce in args
+        ]
 
         return response
 

--- a/analytics_data_api/v0/tests/views/test_engagement_timelines.py
+++ b/analytics_data_api/v0/tests/views/test_engagement_timelines.py
@@ -1,17 +1,23 @@
+from __future__ import absolute_import
+
 import datetime
 import json
 
 import ddt
-
-from django.utils.http import urlquote
 import pytz
+from django.utils.http import urlquote
 from rest_framework import status
 
-from analyticsdataserver.tests import TestCaseWithAuthentication
-from analytics_data_api.constants.engagement_events import (ATTEMPTED, COMPLETED, CONTRIBUTED, DISCUSSION,
-                                                            PROBLEM, VIDEO, VIEWED)
-from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin
+from analytics_data_api.constants.engagement_events import (ATTEMPTED,
+                                                            COMPLETED,
+                                                            CONTRIBUTED,
+                                                            DISCUSSION,
+                                                            PROBLEM, VIDEO,
+                                                            VIEWED)
 from analytics_data_api.v0.tests.utils import create_engagement
+from analytics_data_api.v0.tests.views import (CourseSamples,
+                                               VerifyCourseIdMixin)
+from analyticsdataserver.tests import TestCaseWithAuthentication
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_engagement_timelines.py
+++ b/analytics_data_api/v0/tests/views/test_engagement_timelines.py
@@ -3,20 +3,22 @@ from __future__ import absolute_import
 import datetime
 import json
 
-import ddt
 import pytz
 from django.utils.http import urlquote
 from rest_framework import status
 
-from analytics_data_api.constants.engagement_events import (ATTEMPTED,
-                                                            COMPLETED,
-                                                            CONTRIBUTED,
-                                                            DISCUSSION,
-                                                            PROBLEM, VIDEO,
-                                                            VIEWED)
+import ddt
+from analytics_data_api.constants.engagement_events import (
+    ATTEMPTED,
+    COMPLETED,
+    CONTRIBUTED,
+    DISCUSSION,
+    PROBLEM,
+    VIDEO,
+    VIEWED
+)
 from analytics_data_api.v0.tests.utils import create_engagement
-from analytics_data_api.v0.tests.views import (CourseSamples,
-                                               VerifyCourseIdMixin)
+from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 

--- a/analytics_data_api/v0/tests/views/test_engagement_timelines.py
+++ b/analytics_data_api/v0/tests/views/test_engagement_timelines.py
@@ -15,7 +15,7 @@ from analytics_data_api.constants.engagement_events import (
     DISCUSSION,
     PROBLEM,
     VIDEO,
-    VIEWED
+    VIEWED,
 )
 from analytics_data_api.v0.tests.utils import create_engagement
 from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -16,7 +16,7 @@ from elasticsearch import Elasticsearch
 from mock import Mock, patch
 from rest_framework import status
 from six.moves import range, zip
-from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from analytics_data_api.constants import engagement_events
 from analytics_data_api.v0.models import ModuleEngagementMetricRanges

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -7,24 +7,22 @@ import datetime
 import json
 from itertools import groupby
 
-import ddt
 from django.conf import settings
 from django.core import management
 from django.test import override_settings
-from django_dynamic_fixture import G
 from elasticsearch import Elasticsearch
-from mock import Mock, patch
 from rest_framework import status
 from six.moves import range, zip
 from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
+import ddt
 from analytics_data_api.constants import engagement_events
 from analytics_data_api.v0.models import ModuleEngagementMetricRanges
-from analytics_data_api.v0.tests.views import (CourseSamples,
-                                               VerifyCourseIdMixin,
-                                               VerifyCsvResponseMixin)
+from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin, VerifyCsvResponseMixin
 from analytics_data_api.v0.views import CsvViewMixin, PaginatedHeadersMixin
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
+from mock import Mock, patch
 
 
 class LearnerAPITestMixin(CsvViewMixin):

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -1,28 +1,30 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import copy
 import datetime
-from itertools import groupby
 import json
-from urllib import urlencode
+from itertools import groupby
 
 import ddt
-from django_dynamic_fixture import G
-from elasticsearch import Elasticsearch
-from mock import patch, Mock
-from rest_framework import status
-
 from django.conf import settings
 from django.core import management
 from django.test import override_settings
+from django_dynamic_fixture import G
+from elasticsearch import Elasticsearch
+from mock import Mock, patch
+from rest_framework import status
+from six.moves import range, zip
+from six.moves.urllib.parse import urlencode
 
-from analyticsdataserver.tests import TestCaseWithAuthentication
 from analytics_data_api.constants import engagement_events
 from analytics_data_api.v0.models import ModuleEngagementMetricRanges
+from analytics_data_api.v0.tests.views import (CourseSamples,
+                                               VerifyCourseIdMixin,
+                                               VerifyCsvResponseMixin)
 from analytics_data_api.v0.views import CsvViewMixin, PaginatedHeadersMixin
-from analytics_data_api.v0.tests.views import (
-    CourseSamples, VerifyCourseIdMixin, VerifyCsvResponseMixin,
-)
+from analyticsdataserver.tests import TestCaseWithAuthentication
 
 
 class LearnerAPITestMixin(CsvViewMixin):
@@ -689,7 +691,7 @@ class CourseLearnerMetadataTests(VerifyCourseIdMixin, LearnerAPITestMixin, TestC
         learners = [
             {'username': '{}_{}'.format(segment, i), 'course_id': course_id, 'segments': [segment]}
             for segment, count in segments.items()
-            for i in xrange(count)
+            for i in range(count)
         ]
         self.create_learners(learners)
         expected_segments = {"highly_engaged": 0, "disengaging": 0, "struggling": 0, "inactive": 0, "unenrolled": 0}

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -13,7 +13,7 @@ from analytics_data_api.v0 import models
 from analytics_data_api.v0.serializers import (
     GradeDistributionSerializer,
     ProblemFirstLastResponseAnswerDistributionSerializer,
-    SequentialOpenDistributionSerializer
+    SequentialOpenDistributionSerializer,
 )
 from analyticsdataserver.tests import TestCaseWithAuthentication
 from django_dynamic_fixture import G

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -5,13 +5,17 @@
 
 # pylint: disable=no-member,no-value-for-parameter
 
+from __future__ import absolute_import
+
 import json
 
 from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models
-from analytics_data_api.v0.serializers import ProblemFirstLastResponseAnswerDistributionSerializer, \
-    GradeDistributionSerializer, SequentialOpenDistributionSerializer
+from analytics_data_api.v0.serializers import (
+    GradeDistributionSerializer,
+    ProblemFirstLastResponseAnswerDistributionSerializer,
+    SequentialOpenDistributionSerializer)
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -9,14 +9,14 @@ from __future__ import absolute_import
 
 import json
 
-from django_dynamic_fixture import G
-
 from analytics_data_api.v0 import models
 from analytics_data_api.v0.serializers import (
     GradeDistributionSerializer,
     ProblemFirstLastResponseAnswerDistributionSerializer,
-    SequentialOpenDistributionSerializer)
+    SequentialOpenDistributionSerializer
+)
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
 
 
 class AnswerDistributionTests(TestCaseWithAuthentication):

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 
 import datetime
 
-import ddt
-from django_dynamic_fixture import G
 from six.moves import zip
 
+import ddt
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import (APIListViewTestMixin,
-                                               CourseSamples)
+from analytics_data_api.v0.tests.views import APIListViewTestMixin, CourseSamples
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -1,9 +1,14 @@
+from __future__ import absolute_import
+
 import datetime
+
 import ddt
 from django_dynamic_fixture import G
+from six.moves import zip
 
 from analytics_data_api.v0 import models, serializers
-from analytics_data_api.v0.tests.views import CourseSamples, APIListViewTestMixin
+from analytics_data_api.v0.tests.views import (APIListViewTestMixin,
+                                               CourseSamples)
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
 

--- a/analytics_data_api/v0/tests/views/test_utils.py
+++ b/analytics_data_api/v0/tests/views/test_utils.py
@@ -1,12 +1,13 @@
-import ddt
-from mock import Mock
+from __future__ import absolute_import
 
+import ddt
 from django.http import Http404
 from django.test import TestCase
+from mock import Mock
 
+import analytics_data_api.v0.views.utils as utils
 from analytics_data_api.v0.exceptions import CourseKeyMalformedError
 from analytics_data_api.v0.tests.views import CourseSamples
-import analytics_data_api.v0.views.utils as utils
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_utils.py
+++ b/analytics_data_api/v0/tests/views/test_utils.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 import analytics_data_api.v0.views.utils as utils
 import ddt
-from analytics_data_api.v0.exceptions import CourseKeyMalformedError
+from analytics_data_api.v0.exceptions import CourseKeyMalformedError  # pylint: disable=ungrouped-imports
 from analytics_data_api.v0.tests.views import CourseSamples
 from mock import Mock
 

--- a/analytics_data_api/v0/tests/views/test_utils.py
+++ b/analytics_data_api/v0/tests/views/test_utils.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
-import ddt
 from django.http import Http404
 from django.test import TestCase
-from mock import Mock
 
 import analytics_data_api.v0.views.utils as utils
+import ddt
 from analytics_data_api.v0.exceptions import CourseKeyMalformedError
 from analytics_data_api.v0.tests.views import CourseSamples
+from mock import Mock
 
 
 @ddt.ddt

--- a/analytics_data_api/v0/tests/views/test_videos.py
+++ b/analytics_data_api/v0/tests/views/test_videos.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import datetime
 
 from django.conf import settings

--- a/analytics_data_api/v0/tests/views/test_videos.py
+++ b/analytics_data_api/v0/tests/views/test_videos.py
@@ -4,10 +4,10 @@ import datetime
 
 from django.conf import settings
 from django.utils import timezone
-from django_dynamic_fixture import G
 
 from analytics_data_api.v0 import models
 from analyticsdataserver.tests import TestCaseWithAuthentication
+from django_dynamic_fixture import G
 
 
 class VideoTimelineTests(TestCaseWithAuthentication):

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -1,4 +1,6 @@
-from django.conf.urls import url, include
+from __future__ import absolute_import
+
+from django.conf.urls import include, url
 from django.core.urlresolvers import reverse_lazy
 from django.views.generic import RedirectView
 

--- a/analytics_data_api/v0/urls/course_summaries.py
+++ b/analytics_data_api/v0/urls/course_summaries.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import url
 
 from analytics_data_api.v0.views import course_summaries as views

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import url
 
 from analytics_data_api.v0.urls import COURSE_ID_PATTERN

--- a/analytics_data_api/v0/urls/learners.py
+++ b/analytics_data_api/v0/urls/learners.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import url
 
 from analytics_data_api.v0.urls import COURSE_ID_PATTERN

--- a/analytics_data_api/v0/urls/problems.py
+++ b/analytics_data_api/v0/urls/problems.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import re
 
 from django.conf.urls import url

--- a/analytics_data_api/v0/urls/programs.py
+++ b/analytics_data_api/v0/urls/programs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import url
 
 from analytics_data_api.v0.views import programs as views

--- a/analytics_data_api/v0/urls/videos.py
+++ b/analytics_data_api/v0/urls/videos.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import re
 
 from django.conf.urls import url

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -1,19 +1,18 @@
+from __future__ import absolute_import
+
+from functools import reduce
 from itertools import groupby
 
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics, serializers
 
-from opaque_keys.edx.keys import CourseKey
-
 from analytics_data_api.v0.exceptions import CourseNotSpecifiedError
-from analytics_data_api.v0.views.utils import (
-    raise_404_if_none,
-    split_query_argument,
-    validate_course_id
-)
+from analytics_data_api.v0.views.utils import (raise_404_if_none,
+                                               split_query_argument,
+                                               validate_course_id)
 
 
 class CourseViewMixin(object):

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from functools import reduce
+from functools import reduce as functools_reduce
 from itertools import groupby
 
 from django.db import models
@@ -251,7 +251,7 @@ class APIListView(generics.ListAPIView):
         return aggregate_field_dict
 
     def get_query(self):
-        return reduce(lambda q, item_id: q | Q(id=item_id), self.ids, Q())
+        return functools_reduce(lambda q, item_id: q | Q(id=item_id), self.ids, Q())
 
     @raise_404_if_none
     def get_queryset(self):

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -10,9 +10,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics, serializers
 
 from analytics_data_api.v0.exceptions import CourseNotSpecifiedError
-from analytics_data_api.v0.views.utils import (raise_404_if_none,
-                                               split_query_argument,
-                                               validate_course_id)
+from analytics_data_api.v0.views.utils import raise_404_if_none, split_query_argument, validate_course_id
 
 
 class CourseViewMixin(object):

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime
-from functools import reduce
+from functools import reduce as functools_reduce
 
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
@@ -216,4 +216,4 @@ class CourseSummariesView(APIListView):
         return field_dict
 
     def get_query(self):
-        return reduce(lambda q, item_id: q | Q(course_id=item_id), self.ids, Q())
+        return functools_reduce(lambda q, item_id: q | Q(course_id=item_id), self.ids, Q())

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -9,8 +9,7 @@ from django.http import HttpResponseBadRequest
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.views import APIListView
-from analytics_data_api.v0.views.utils import (split_query_argument,
-                                               validate_course_id)
+from analytics_data_api.v0.views.utils import split_query_argument, validate_course_id
 
 
 class CourseSummariesView(APIListView):

--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import
+
 from datetime import datetime
+from functools import reduce
 
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
@@ -6,10 +9,8 @@ from django.http import HttpResponseBadRequest
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.views import APIListView
-from analytics_data_api.v0.views.utils import (
-    split_query_argument,
-    validate_course_id,
-)
+from analytics_data_api.v0.views.utils import (split_query_argument,
+                                               validate_course_id)
 
 
 class CourseSummariesView(APIListView):

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -16,8 +16,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from analytics_data_api.constants import enrollment_modes
-from analytics_data_api.utils import (dictfetchall,
-                                      get_course_report_download_details)
+from analytics_data_api.utils import dictfetchall, get_course_report_download_details
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.exceptions import ReportFileNotFoundError
 from analytics_data_api.v0.models import ModuleEngagement

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import datetime
-from itertools import groupby
 import warnings
+from itertools import groupby
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -8,21 +10,18 @@ from django.db import connections
 from django.db.models import Max
 from django.http import Http404
 from django.utils.timezone import make_aware, utc
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from opaque_keys.edx.keys import CourseKey
 
 from analytics_data_api.constants import enrollment_modes
-from analytics_data_api.utils import dictfetchall, get_course_report_download_details
+from analytics_data_api.utils import (dictfetchall,
+                                      get_course_report_download_details)
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.exceptions import ReportFileNotFoundError
-
+from analytics_data_api.v0.models import ModuleEngagement
 from analytics_data_api.v0.views.utils import raise_404_if_none
-
-from analytics_data_api.v0.models import (
-    ModuleEngagement,
-)
 
 
 class BaseCourseView(generics.ListAPIView):
@@ -750,7 +749,7 @@ class ProblemsAndTagsListView(BaseCourseView):
                     'created': v.created
                 }
 
-        return result.values()
+        return list(result.values())
 
 
 class VideosListView(BaseCourseView):

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -10,7 +10,7 @@ from rest_framework import generics, status
 from analytics_data_api.v0.exceptions import (
     LearnerEngagementTimelineNotFoundError,
     LearnerNotFoundError,
-    ParameterValueError
+    ParameterValueError,
 )
 from analytics_data_api.v0.models import ModuleEngagement, ModuleEngagementMetricRanges, RosterEntry, RosterUpdate
 from analytics_data_api.v0.serializers import (
@@ -18,7 +18,7 @@ from analytics_data_api.v0.serializers import (
     EdxPaginationSerializer,
     EngagementDaySerializer,
     LastUpdatedSerializer,
-    LearnerSerializer
+    LearnerSerializer,
 )
 from analytics_data_api.v0.views import CourseViewMixin, CsvViewMixin, PaginatedHeadersMixin
 from analytics_data_api.v0.views.utils import split_query_argument

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -1,31 +1,26 @@
 """
 API methods for module level data.
 """
+from __future__ import absolute_import
+
 import logging
 
 from rest_framework import generics, status
 
 from analytics_data_api.v0.exceptions import (
-    LearnerEngagementTimelineNotFoundError,
-    LearnerNotFoundError,
-    ParameterValueError,
-)
-from analytics_data_api.v0.models import (
-    ModuleEngagement,
-    ModuleEngagementMetricRanges,
-    RosterEntry,
-    RosterUpdate,
-)
-from analytics_data_api.v0.serializers import (
-    CourseLearnerMetadataSerializer,
-    EdxPaginationSerializer,
-    EngagementDaySerializer,
-    LastUpdatedSerializer,
-    LearnerSerializer,
-)
-from analytics_data_api.v0.views import CourseViewMixin, PaginatedHeadersMixin, CsvViewMixin
+    LearnerEngagementTimelineNotFoundError, LearnerNotFoundError,
+    ParameterValueError)
+from analytics_data_api.v0.models import (ModuleEngagement,
+                                          ModuleEngagementMetricRanges,
+                                          RosterEntry, RosterUpdate)
+from analytics_data_api.v0.serializers import (CourseLearnerMetadataSerializer,
+                                               EdxPaginationSerializer,
+                                               EngagementDaySerializer,
+                                               LastUpdatedSerializer,
+                                               LearnerSerializer)
+from analytics_data_api.v0.views import (CourseViewMixin, CsvViewMixin,
+                                         PaginatedHeadersMixin)
 from analytics_data_api.v0.views.utils import split_query_argument
-
 
 logger = logging.getLogger(__name__)
 

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -8,18 +8,19 @@ import logging
 from rest_framework import generics, status
 
 from analytics_data_api.v0.exceptions import (
-    LearnerEngagementTimelineNotFoundError, LearnerNotFoundError,
-    ParameterValueError)
-from analytics_data_api.v0.models import (ModuleEngagement,
-                                          ModuleEngagementMetricRanges,
-                                          RosterEntry, RosterUpdate)
-from analytics_data_api.v0.serializers import (CourseLearnerMetadataSerializer,
-                                               EdxPaginationSerializer,
-                                               EngagementDaySerializer,
-                                               LastUpdatedSerializer,
-                                               LearnerSerializer)
-from analytics_data_api.v0.views import (CourseViewMixin, CsvViewMixin,
-                                         PaginatedHeadersMixin)
+    LearnerEngagementTimelineNotFoundError,
+    LearnerNotFoundError,
+    ParameterValueError
+)
+from analytics_data_api.v0.models import ModuleEngagement, ModuleEngagementMetricRanges, RosterEntry, RosterUpdate
+from analytics_data_api.v0.serializers import (
+    CourseLearnerMetadataSerializer,
+    EdxPaginationSerializer,
+    EngagementDaySerializer,
+    LastUpdatedSerializer,
+    LearnerSerializer
+)
+from analytics_data_api.v0.views import CourseViewMixin, CsvViewMixin, PaginatedHeadersMixin
 from analytics_data_api.v0.views.utils import split_query_argument
 
 logger = logging.getLogger(__name__)

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -13,12 +13,17 @@ from rest_framework import generics
 
 from analytics_data_api.utils import matching_tuple
 from analytics_data_api.v0.models import (
-    GradeDistribution, ProblemFirstLastResponseAnswerDistribution,
-    ProblemResponseAnswerDistribution, SequentialOpenDistribution)
+    GradeDistribution,
+    ProblemFirstLastResponseAnswerDistribution,
+    ProblemResponseAnswerDistribution,
+    SequentialOpenDistribution
+)
 from analytics_data_api.v0.serializers import (
     ConsolidatedAnswerDistributionSerializer,
     ConsolidatedFirstLastAnswerDistributionSerializer,
-    GradeDistributionSerializer, SequentialOpenDistributionSerializer)
+    GradeDistributionSerializer,
+    SequentialOpenDistributionSerializer
+)
 from analytics_data_api.v0.views.utils import raise_404_if_none
 
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -16,13 +16,13 @@ from analytics_data_api.v0.models import (
     GradeDistribution,
     ProblemFirstLastResponseAnswerDistribution,
     ProblemResponseAnswerDistribution,
-    SequentialOpenDistribution
+    SequentialOpenDistribution,
 )
 from analytics_data_api.v0.serializers import (
     ConsolidatedAnswerDistributionSerializer,
     ConsolidatedFirstLastAnswerDistributionSerializer,
     GradeDistributionSerializer,
-    SequentialOpenDistributionSerializer
+    SequentialOpenDistributionSerializer,
 )
 from analytics_data_api.v0.views.utils import raise_404_if_none
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -2,26 +2,23 @@
 API methods for module level data.
 """
 
+from __future__ import absolute_import
+
 from collections import defaultdict
 from itertools import groupby
 
+import six
 from django.db import OperationalError
 from rest_framework import generics
 
+from analytics_data_api.utils import matching_tuple
 from analytics_data_api.v0.models import (
-    GradeDistribution,
-    ProblemResponseAnswerDistribution,
-    ProblemFirstLastResponseAnswerDistribution,
-    SequentialOpenDistribution,
-)
+    GradeDistribution, ProblemFirstLastResponseAnswerDistribution,
+    ProblemResponseAnswerDistribution, SequentialOpenDistribution)
 from analytics_data_api.v0.serializers import (
     ConsolidatedAnswerDistributionSerializer,
     ConsolidatedFirstLastAnswerDistributionSerializer,
-    GradeDistributionSerializer,
-    SequentialOpenDistributionSerializer,
-)
-from analytics_data_api.utils import matching_tuple
-
+    GradeDistributionSerializer, SequentialOpenDistributionSerializer)
 from analytics_data_api.v0.views.utils import raise_404_if_none
 
 
@@ -70,13 +67,13 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
             match_tuple_sets[answer.value_id].add(matching_tuple(answer))
 
         # If a part has more than one unique tuple of matching fields, do not consolidate.
-        for _, match_tuple_set in match_tuple_sets.iteritems():
+        for _, match_tuple_set in six.iteritems(match_tuple_sets):
             if len(match_tuple_set) > 1:
                 return problem
 
         consolidated_answers = []
 
-        for _, answers in answer_sets.iteritems():
+        for _, answers in six.iteritems(answer_sets):
             consolidated_answer = None
 
             if len(answers) == 1:

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+
+from functools import reduce
+
 from django.db.models import Q
 
 from analytics_data_api.v0 import models, serializers

--- a/analytics_data_api/v0/views/programs.py
+++ b/analytics_data_api/v0/views/programs.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from functools import reduce
+from functools import reduce as functools_reduce
 
 from django.db.models import Q
 
@@ -64,4 +64,4 @@ class ProgramsView(APIListView):
         return field_dict
 
     def get_query(self):
-        return reduce(lambda q, item_id: q | Q(program_id=item_id), self.ids, Q())
+        return functools_reduce(lambda q, item_id: q | Q(program_id=item_id), self.ids, Q())

--- a/analytics_data_api/v0/views/utils.py
+++ b/analytics_data_api/v0/views/utils.py
@@ -1,6 +1,7 @@
 """Utilities for view-level API logic."""
-from django.http import Http404
+from __future__ import absolute_import
 
+from django.http import Http404
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 

--- a/analytics_data_api/v0/views/videos.py
+++ b/analytics_data_api/v0/views/videos.py
@@ -2,11 +2,12 @@
 API methods for module level data.
 """
 
+from __future__ import absolute_import
+
 from rest_framework import generics
 
 from analytics_data_api.v0.models import VideoTimeline
 from analytics_data_api.v0.serializers import VideoTimelineSerializer
-
 from analytics_data_api.v0.views.utils import raise_404_if_none
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -38,6 +38,7 @@ disable=
 # R0922: Abstract class is only referenced 1 times
     I0011,W0141,W0142,R0921,R0922,
 
+   duplicate-code,
 # Django makes classes that trigger these
 # W0232: Class has no __init__ method
     W0232,

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ max_line_length=119
 exclude=settings,analyticsdataserver/wsgi.py
 
 [isort]
-indent='    '
-line_length=120
-multi_line_output=3
+include_trailing_comma = True
+indent = '    '
+line_length = 120
+multi_line_output = 3


### PR DESCRIPTION
### Description

Modernize analytics_data_api/v0 with the following commands:

- python-modernize -w analytics_data_api/v0
- isort -rc analytics_data_api/v0

Then they were solved (or disabled) the quality errors (disabled duplicate-code in pylint)

## Reviewers
 - [ ] @andrey-canon
 - [ ] Is this ready for edX's review?
 - [ ] @jmbowman 
