### PR TITLE
[BD] Do not install futures in python3

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,9 @@
 # Core dependencies go here
 
+-c constraints.txt
+
 boto==2.42.0                        # MIT
-django<1.12                         # BSD License
+Django                              # BSD License
 django-countries==4.5               # MIT
 python-memcached                    # Python Software Foundation License v2
 djangorestframework                 # BSD

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+django==1.11.27           # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
@@ -48,7 +48,7 @@ elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
-futures==3.2.0            # via edx-enterprise-data, s3transfer
+futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, edx-enterprise-data, s3transfer
 idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,18 @@
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why.  Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
+
+# TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
+
+# Django 2 drops Python 2.7 support
+Django<2.0.0
+
+# Already in python3 standard library
+futures; python_version == "2.7"
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+django==1.11.27           # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
@@ -48,7 +48,7 @@ elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
-futures==3.2.0            # via edx-enterprise-data, s3transfer
+futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, edx-enterprise-data, s3transfer
 idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -31,7 +31,7 @@ django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+django==1.11.27           # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
@@ -48,7 +48,7 @@ elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
-futures==3.2.0            # via edx-enterprise-data, s3transfer
+futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, edx-enterprise-data, s3transfer
 idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, pluggy
 ipaddress==1.0.23         # via cryptography, edx-enterprise-data

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -31,7 +31,7 @@ django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+django==1.11.27           # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
@@ -48,7 +48,7 @@ elasticsearch-dsl==0.0.11  # via -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
-futures==3.2.0            # via edx-enterprise-data, s3transfer
+futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, edx-enterprise-data, s3transfer
 gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
 gunicorn==19.6.0          # via -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,7 +40,7 @@ django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions, edx-enterprise-data
-django==1.11.27           # via -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
+django==1.11.27           # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions, edx-enterprise-data
 djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, edx-drf-extensions, edx-enterprise-data, rest-condition
@@ -58,7 +58,7 @@ elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 funcsigs==1.0.2           # via mock, pytest
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python
-futures==3.2.0            # via edx-enterprise-data, isort, s3transfer
+futures==3.2.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, edx-enterprise-data, isort, s3transfer
 idna==2.8                 # via edx-enterprise-data, requests
 importlib-metadata==1.3.0  # via edx-enterprise-data, inflect, pluggy, pytest
 inflect==3.0.2            # via jinja2-pluralize


### PR DESCRIPTION
Upgrade django constraints. https://openedx.atlassian.net/projects/BOM/issues/BOM-1359

This PR and https://github.com/edx/edx-analytics-data-api/pull/307 are intended to be done in order to avoid failures with pip3 installation of the dependencies

Django is not being updated due to it is not upgraded in edx-enterprise and there it is being used the base.txt file to load the requirements

## Constraints changed
Django from <1.12 to <2.0.0

futures requires python2.7

### Reviewers
- [ ] @andrey-canon
- [ ] Is this ready for edX's review?
- [ ] @jmbowman 


### Post-review
-  Rebase and squash commits
