### PR TITLE
[BD] Change assertItemsEqual with six.assertCountEqual

### DIFF
--- a/analytics_data_api/v0/tests/views/__init__.py
+++ b/analytics_data_api/v0/tests/views/__init__.py
@@ -156,13 +156,13 @@ class APIListViewTestMixin(object):
         self.generate_data()
         response = self.validated_request(ids=ids, exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_results(ids=ids))
+        six.assertCountEqual(self, response.data, self.all_expected_results(ids=ids))
 
     def _test_one_item(self, item_id):
         self.generate_data()
         response = self.validated_request(ids=[item_id], exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, [self.expected_result(item_id)])
+        six.assertCountEqual(self, response.data, [self.expected_result(item_id)])
 
     def _test_fields(self, fields):
         self.generate_data()
@@ -175,7 +175,7 @@ class APIListViewTestMixin(object):
             for field_to_remove in set(expected_result.keys()) - set(fields):
                 expected_result.pop(field_to_remove)
 
-        self.assertItemsEqual(response.data, expected_results)
+        six.assertCountEqual(self, response.data, expected_results)
 
     def test_no_items(self):
         response = self.validated_request()

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import datetime
 
 import pytz
+import six
 from django.conf import settings
 
 import ddt
@@ -152,7 +153,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         self.generate_data(modes=modes)
         response = self.validated_request(exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_results(modes=modes))
+        six.assertCountEqual(self, response.data, self.all_expected_results(modes=modes))
 
     @ddt.data(
         ['malformed-course-id'],
@@ -172,13 +173,13 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         expected_summaries.extend(self.all_expected_results(ids=['foo/bar/baz'],
                                                             availability='Upcoming'))
 
-        self.assertItemsEqual(response.data, expected_summaries)
+        six.assertCountEqual(self, response.data, expected_summaries)
 
     def test_programs(self):
         self.generate_data(programs=True)
         response = self.validated_request(exclude=self.always_exclude[:1], programs=['True'])
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_results(programs=True))
+        six.assertCountEqual(self, response.data, self.all_expected_results(programs=True))
 
     @ddt.data('passing_users', )
     def test_exclude(self, field):
@@ -196,7 +197,7 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         count_factor = 5
         expected_count_change = count_factor * len(enrollment_modes.ALL)
         expected = self.all_expected_results(modes=enrollment_modes.ALL, recent_count_change=expected_count_change)
-        self.assertItemsEqual(response.data, expected)
+        six.assertCountEqual(self, response.data, expected)
 
     def test_recent_bad_date(self):
         'Tests that sending a bad recent_date returns 400'
@@ -225,15 +226,15 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
 
         responseOnDate = self.validated_request(exclude=self.always_exclude, recent_date=recent.strftime('%Y-%m-%d'))
         self.assertEquals(responseOnDate.status_code, 200)
-        self.assertItemsEqual(responseOnDate.data, expectedOnDate)
+        six.assertCountEqual(self, responseOnDate.data, expectedOnDate)
 
         after = (recent + datetime.timedelta(1)).strftime('%Y-%m-%d')
         responseAfterDate = self.validated_request(exclude=self.always_exclude, recent_date=after)
         self.assertEquals(responseAfterDate.status_code, 200)
-        self.assertItemsEqual(responseAfterDate.data, expectedOnDate)
+        six.assertCountEqual(self, responseAfterDate.data, expectedOnDate)
 
         expectedBeforeDate = self.all_expected_results(modes=enrollment_modes.ALL, recent_count_change=expected_count)
         before = (recent - datetime.timedelta(1)).strftime('%Y-%m-%d')
         responseBeforeDate = self.validated_request(exclude=self.always_exclude, recent_date=before)
         self.assertEquals(responseBeforeDate.status_code, 200)
-        self.assertItemsEqual(responseBeforeDate.data, expectedBeforeDate)
+        six.assertCountEqual(self, responseBeforeDate.data, expectedBeforeDate)

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import datetime
 
+import six
 from six.moves import zip
 
 import ddt
@@ -103,4 +104,4 @@ class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
         self.generate_data(ids=program_ids, course_ids=course_ids)
         response = self.validated_request(ids=program_ids, exclude=self.always_exclude)
         self.assertEquals(response.status_code, 200)
-        self.assertItemsEqual(response.data, self.all_expected_results(ids=program_ids, course_ids=course_ids))
+        six.assertCountEqual(self, response.data, self.all_expected_results(ids=program_ids, course_ids=course_ids))


### PR DESCRIPTION
## Description
See https://openedx.atlassian.net/browse/BOM-1359
In python 3, assertItemsEqual was dropped. six.assertCountEqual is an alias for assertCountEqual() on Python 3 and assertItemsEqual() on Python 2.
https://six.readthedocs.io/#six.assertCountEqual

Change based on https://github.com/edx/edx-platform/commit/8a95a8e520cfcd64ec404e794d5e95c042c5c51b
This is one of the errors that we have currently in the python3 version (see tests in https://github.com/eduNEXT/edx-analytics-data-api/pull/1)

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 

