### PR TITLE
[BD] Stop using deprecated BaseException.message

### DIFF
--- a/analytics_data_api/v0/views/course_summaries.py
+++ b/analytics_data_api/v0/views/course_summaries.py
@@ -5,6 +5,7 @@ from functools import reduce as functools_reduce
 
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
+from six import text_type
 
 from analytics_data_api.constants import enrollment_modes
 from analytics_data_api.v0 import models, serializers
@@ -95,7 +96,7 @@ class CourseSummariesView(APIListView):
         try:
             self.verify_recent_date(recent)
         except ValueError as err:
-            return HttpResponseBadRequest(content='Error in recent_date: {}\n'.format(err.message))
+            return HttpResponseBadRequest(content='Error in recent_date: {}\n'.format(text_type(err)))
 
         response = super(CourseSummariesView, self).get(request, *args, **kwargs)
         return response
@@ -114,7 +115,7 @@ class CourseSummariesView(APIListView):
             if recent:
                 self.verify_recent_date(recent[0])  # Post argument always comes in as a list
         except ValueError as err:
-            return HttpResponseBadRequest(content='Error in recent_date: {}\n'.format(err.message))
+            return HttpResponseBadRequest(content='Error in recent_date: {}\n'.format(text_type(err)))
 
         response = super(CourseSummariesView, self).post(request, *args, **kwargs)
         return response

--- a/analytics_data_api/v0/views/learners.py
+++ b/analytics_data_api/v0/views/learners.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import logging
 
 from rest_framework import generics, status
+from six import text_type
 
 from analytics_data_api.v0.exceptions import (
     LearnerEngagementTimelineNotFoundError,
@@ -290,8 +291,8 @@ class LearnerListView(LastUpdateMixin, CourseViewMixin, PaginatedHeadersMixin, C
         params = {key: val for key, val in params.items() if val is not None}
         try:
             return RosterEntry.get_users_in_course(self.course_id, **params)
-        except ValueError as e:
-            raise ParameterValueError(e.message)
+        except ValueError as err:
+            raise ParameterValueError(text_type(err))
 
 
 class EngagementTimelineView(CourseViewMixin, generics.ListAPIView):


### PR DESCRIPTION
## Description
See https://openedx.atlassian.net/browse/BOM-1359

BaseException.message is deprecated in python 2.6 https://www.python.org/dev/peps/pep-0352/

The change applied is based on https://github.com/edx/edx-platform/pull/17376/commits

This is one of the errors that we have currently in the python3 version (see tests in https://github.com/eduNEXT/edx-analytics-data-api/pull/1)

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 



