### PR TITLE
[BD] Add compatibility to call log_request_fail in python3

### DIFF
--- a/analytics_data_api/v0/connections.py
+++ b/analytics_data_api/v0/connections.py
@@ -41,7 +41,7 @@ class BotoHttpConnection(Connection):
         See: https://github.com/boto/boto/blob/develop/boto/connection.py#L533
         """
         if not isinstance(body, six.string_types):
-            body = json.dumps(body)
+            body = json.dumps(body).encode('UTF-8')
         start = time.time()
         response = self.connection.make_request(method, url, params=params, data=body)
         duration = time.time() - start

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,7 +12,7 @@ djangorestframework-csv             # BSD
 
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9                 # BSD
-elasticsearch-dsl==0.0.11           # Apache 2.0
+elasticsearch-dsl                   # Apache 2.0
 ordered-set==2.0.2                  # MIT
 tqdm==4.11.2                        # MIT
 urllib3                             # MIT

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,7 @@ edx-enterprise-data==1.3.13  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
-elasticsearch-dsl==0.0.11  # via -r requirements/base.in
+elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,3 +21,6 @@ mysqlclient==1.4.6
 
 # django-countries version 6.0.0 dropped support to Python 2.7
 django-countries<6.0.0
+
+# elasticsearch-dsl depends on elasticsearch >2.0.0,<3.0.0
+elasticsearch-dsl<2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ edx-enterprise-data==1.3.13  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
-elasticsearch-dsl==0.0.11  # via -r requirements/base.in
+elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,7 +44,7 @@ edx-enterprise-data==1.3.13  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
-elasticsearch-dsl==0.0.11  # via -r requirements/base.in
+elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -44,7 +44,7 @@ edx-enterprise-data==1.3.13  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
-elasticsearch-dsl==0.0.11  # via -r requirements/base.in
+elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 future==0.18.2            # via edx-enterprise-data, pyjwkest, vertica-python

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,7 +53,7 @@ edx-enterprise-data==1.3.13  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
 edx-rbac==1.0.5           # via edx-enterprise-data
 edx-rest-api-client==1.9.2  # via -r requirements/base.in, edx-enterprise-data
-elasticsearch-dsl==0.0.11  # via -r requirements/base.in
+elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 enum34==1.1.6             # via cryptography, edx-enterprise-data, pgpy
 funcsigs==1.0.2           # via mock, pytest
@@ -80,7 +80,7 @@ neotime==1.7.4            # via edx-enterprise-data, py2neo
 newrelic==5.4.1.134       # via edx-django-utils, edx-enterprise-data
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==2.0.2        # via -r requirements/base.in
-packaging==20.1           # via pytest
+packaging==20.3           # via pytest
 paramiko==2.4             # via edx-enterprise-data
 pathlib2==2.3.5           # via edx-enterprise-data, importlib-metadata, pytest, pytest-django
 pbr==5.4.4                # via edx-enterprise-data, mock, stevedore


### PR DESCRIPTION
## Description
Related to https://openedx.atlassian.net/browse/BOM-1359

Currently (analytics_data_api.v0.tests.test_connections.BotoHttpConnectionTests) tests are failing when they call self.log_request_fail(method, url, body, duration, response.status) with a `AttributeError: 'str' object has no attribute 'decode'` in
 https://github.com/elastic/elasticsearch-py/blob/1.9.0/elasticsearch/connection/base.py#L88


It seems that it was added a try catch block for that in the [latest versions](https://github.com/elastic/elasticsearch-py/blob/742aadd57b1953afc35524220d93e296954b45d0/elasticsearch/connection/base.py#L206)  of elasticsearch-py but the readme  for the 2.x version says that `For Elasticsearch 1.0 and later, use the major version 1 (1.x.y) of the library` https://github.com/elastic/elasticsearch-py/tree/2.x

I also moved the constraints of elasticsearch-dsl to constraints.txt


This is one of the errors that we have currently in the python3 version (see tests in https://github.com/eduNEXT/edx-analytics-data-api/pull/1)

## Reviewers
 - [x] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 




