### PR TITLE
[BD] Solve sorting issues in python 3

### DIFF
--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -724,7 +724,7 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
 
         response = self._get_data(course_id)
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual(sorted([dict(d) for d in response.data]), sorted(expected))
+        six.assertCountEqual(self, [dict(d) for d in response.data], expected)
 
     def test_get_404(self):
         """

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -592,7 +592,7 @@ class CourseEnrollmentByLocationView(BaseCourseEnrollmentView):
         items = queryset.all()
 
         # Data must be sorted in order for groupby to work properly
-        items = sorted(items, key=lambda x: x.country.alpha2)
+        items = sorted(items, key=lambda x: '' if x.country.alpha2 is None else x.country.alpha2)
 
         # Items to be returned by this method
         returned_items = []


### PR DESCRIPTION
## Description
Related to https://openedx.atlassian.net/browse/BOM-1359

Addressing python 3 changes in ordering comparisons. https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons

```python
>       self.assertListEqual(sorted([dict(d) for d in response.data]), sorted(expected))
E       TypeError: unorderable types: dict() < dict()
```
In this case, I think that we do not need to sort the lists since we can use six.assertCountEqual

```python
>       items = sorted(items, key=lambda x: x.country.alpha2)
E       TypeError: unorderable types: NoneType() < NoneType()
```
In this case I use an empty string if the country alpha2 is None, to avoid that TypeError. The solution is based in https://www.reddit.com/r/Python/comments/9n7vmd/python_3_migration_how_to_properly_sort_lists/

This is one of the errors that we have currently in the python3 version (see tests in https://github.com/eduNEXT/edx-analytics-data-api/pull/1)

## Reviewers
 - [x] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 



