### PR TITLE
[BD] Do not use deprecated MIDDLEWARE_CLASSES

### DIFF
--- a/analytics_data_api/v0/middleware.py
+++ b/analytics_data_api/v0/middleware.py
@@ -4,6 +4,7 @@ import abc
 
 import six
 from django.http.response import JsonResponse
+from django.utils.deprecation import MiddlewareMixin
 from rest_framework import status
 
 from analytics_data_api.v0.exceptions import (
@@ -17,7 +18,7 @@ from analytics_data_api.v0.exceptions import (
 )
 
 
-class BaseProcessErrorMiddleware(six.with_metaclass(abc.ABCMeta, object)):
+class BaseProcessErrorMiddleware(six.with_metaclass(abc.ABCMeta, MiddlewareMixin)):
     """
     Base error.
     """

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -176,8 +176,8 @@ TEMPLATES = [
 
 
 ########## MIDDLEWARE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
-MIDDLEWARE_CLASSES = (
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-MIDDLEWARE
+MIDDLEWARE = [
     # Default Django middleware.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -200,7 +200,7 @@ MIDDLEWARE_CLASSES = (
     'analytics_data_api.v0.middleware.ParameterValueErrorMiddleware',
     'analytics_data_api.v0.middleware.ReportFileNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.CannotCreateDownloadLinkErrorMiddleware',
-)
+]
 ########## END MIDDLEWARE CONFIGURATION
 
 


### PR DESCRIPTION
## Description
Related to https://openedx.atlassian.net/browse/BOM-1359

MIDDLEWARE_CLASSES throws the RemovedInDjango20Warning warning.

I also added the django mixin suggested in https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware that was done also in https://github.com/edx/edx-platform/commit/97d327feeb2028b93fb881eee17aa5d1d66f9b5c

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 




