### PR TITLE
[BD] Migrate all the databases for insights tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ demo: clean requirements loaddata
 	python manage.py set_api_key edx edx
 
 # Target used by edx-analytics-dashboard during its testing.
-travis: clean test.requirements migrate
+travis: clean test.requirements migrate-all
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
 	python manage.py generate_fake_course_data --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"


### PR DESCRIPTION
## Description https://openedx.atlassian.net/browse/BOM-1359

Related to https://github.com/edx/edx-analytics-dashboard/pull/972, the older version used in insights tests migrates both databases when `make travis` is called..

https://github.com/edx/edx-analytics-data-api/blob/dcc7e02b6ae83c69c583a55c5b5a4e2f2665793c/Makefile#L59

In order to use an newer version of data-api, we need to do the changes in the Makefile to migrate both databases, the other option is to add in insights a call to make migrate-all explicitly, but I think that this way is cleaner.

## Reviewers
 - [ ] @andrey-canon
 - [ ] Is this ready for edX's review?
- [ ] @jmbowman 