### PR TITLE
[BD] Fix RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated.

### DIFF
--- a/analytics_data_api/urls.py
+++ b/analytics_data_api/urls.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import
 from django.conf.urls import include, url
 from rest_framework.urlpatterns import format_suffix_patterns
 
+app_name = 'analytics_data_api'
+
 urlpatterns = [
-    url(r'^v0/', include('analytics_data_api.v0.urls', 'v0')),
+    url(r'^v0/', include('analytics_data_api.v0.urls')),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -4,15 +4,17 @@ from django.conf.urls import include, url
 from django.urls import reverse_lazy
 from django.views.generic import RedirectView
 
+app_name = 'analytics_data_api.v0'
+
 COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+[/+][^/+]+[/+][^/]+)'
 
 urlpatterns = [
-    url(r'^courses/', include('analytics_data_api.v0.urls.courses', 'courses')),
-    url(r'^problems/', include('analytics_data_api.v0.urls.problems', 'problems')),
-    url(r'^videos/', include('analytics_data_api.v0.urls.videos', 'videos')),
-    url('^', include('analytics_data_api.v0.urls.learners', 'learners')),
-    url('^', include('analytics_data_api.v0.urls.course_summaries', 'course_summaries')),
-    url('^', include('analytics_data_api.v0.urls.programs', 'programs')),
+    url(r'^courses/', include('analytics_data_api.v0.urls.courses')),
+    url(r'^problems/', include('analytics_data_api.v0.urls.problems')),
+    url(r'^videos/', include('analytics_data_api.v0.urls.videos')),
+    url('^', include('analytics_data_api.v0.urls.learners')),
+    url('^', include('analytics_data_api.v0.urls.course_summaries')),
+    url('^', include('analytics_data_api.v0.urls.programs')),
 
     # pylint: disable=no-value-for-parameter
     url(r'^authenticated/$', RedirectView.as_view(url=reverse_lazy('authenticated')), name='authenticated'),

--- a/analytics_data_api/v0/urls/course_summaries.py
+++ b/analytics_data_api/v0/urls/course_summaries.py
@@ -4,6 +4,8 @@ from django.conf.urls import url
 
 from analytics_data_api.v0.views import course_summaries as views
 
+app_name = 'course_summaries'
+
 urlpatterns = [
     url(r'^course_summaries/$', views.CourseSummariesView.as_view(), name='course_summaries'),
 ]

--- a/analytics_data_api/v0/urls/courses.py
+++ b/analytics_data_api/v0/urls/courses.py
@@ -5,6 +5,8 @@ from django.conf.urls import url
 from analytics_data_api.v0.urls import COURSE_ID_PATTERN
 from analytics_data_api.v0.views import courses as views
 
+app_name = 'courses'
+
 COURSE_URLS = [
     ('activity', views.CourseActivityWeeklyView, 'activity'),
     ('recent_activity', views.CourseActivityMostRecentWeekView, 'recent_activity'),

--- a/analytics_data_api/v0/urls/learners.py
+++ b/analytics_data_api/v0/urls/learners.py
@@ -7,6 +7,8 @@ from analytics_data_api.v0.views import learners as views
 
 from analytics_data_api.constants.learner import UUID_REGEX_PATTERN
 
+app_name = 'learners'
+
 USERNAME_PATTERN = r'(?P<username>[\w.+-]+)'
 
 urlpatterns = [

--- a/analytics_data_api/v0/urls/problems.py
+++ b/analytics_data_api/v0/urls/problems.py
@@ -6,6 +6,8 @@ from django.conf.urls import url
 
 from analytics_data_api.v0.views import problems as views
 
+app_name = 'problems'
+
 PROBLEM_URLS = [
     ('answer_distribution', views.ProblemResponseAnswerDistributionView, 'answer_distribution'),
     ('grade_distribution', views.GradeDistributionView, 'grade_distribution'),

--- a/analytics_data_api/v0/urls/programs.py
+++ b/analytics_data_api/v0/urls/programs.py
@@ -4,6 +4,8 @@ from django.conf.urls import url
 
 from analytics_data_api.v0.views import programs as views
 
+app_name = 'programs'
+
 urlpatterns = [
     url(r'^programs/$', views.ProgramsView.as_view(), name='programs'),
 ]

--- a/analytics_data_api/v0/urls/videos.py
+++ b/analytics_data_api/v0/urls/videos.py
@@ -6,6 +6,8 @@ from django.conf.urls import url
 
 from analytics_data_api.v0.views import videos as views
 
+app_name = 'videos'
+
 VIDEO_URLS = [
     ('timeline', views.VideoTimelineView, 'timeline'),
 ]

--- a/analyticsdataserver/urls.py
+++ b/analyticsdataserver/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls', 'rest_framework')),
     url(r'^api-token-auth/', obtain_auth_token),
 
-    url(r'^api/', include('analytics_data_api.urls', 'api')),
+    url(r'^api/', include('analytics_data_api.urls')),
     url(r'^docs/', views.SwaggerSchemaView.as_view()),
 
     url(r'^status/$', views.StatusView.as_view(), name='status'),


### PR DESCRIPTION
## Description
[BD] Fix RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated.

https://docs.djangoproject.com/en/dev/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include

Related to https://openedx.atlassian.net/browse/BOM-1359

## Reviewers
- [ ] @andrey-canon
- [x] ready for edX review.
- [ ] @jmbowman 