### PR TITLE
[BD] Importing from django.core.urlresolvers is deprecated in favor of dja…

### DIFF
--- a/analytics_data_api/v0/tests/test_urls.py
+++ b/analytics_data_api/v0/tests/test_urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 


### PR DESCRIPTION
…ngo.urls

## Description
Solves the warning: RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.


## Reviewers

- [ ] @andrey-canon
- [ ] ready for edX review
- [ ] @jmbowman 