### PR TITLE
BOM-1410 Updated drf-jwt constraint comment

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9                 # BSD
 # django-waffle version 0.19.0 dropped support to Django 2.0 and 2.1, see https://github.com/django-waffle/django-waffle/blob/master/CHANGES
 django-waffle<0.19.0
 
-# django22 tests are failing. Constraint taken from https://github.com/edx/edx-drf-extensions version 4.0.1
+# django22 tests are failing. Constraint taken from https://github.com/edx/edx-drf-extensions version 5.0.2
 drf-jwt<1.15.0
 
 # edx-django-utils version 3.0.0 dropped support for python 2.7, see https://github.com/edx/edx-django-utils/releases/tag/3.0.0


### PR DESCRIPTION
**Issue:** [BOM-1410](https://openedx.atlassian.net/browse/BOM-1410)

### Description
- Updated `drf-jwt` constraint comment due to version upgrade in `edx-drf-extensions`. 