### PR TITLE
[BD]  Fix schema generation

### DIFF
--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -334,6 +334,10 @@ REST_FRAMEWORK = {
         # For the browseable API
         'rest_framework.authentication.SessionAuthentication',
     ),
+
+    # TODO: Move to OpenAPI https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',


### PR DESCRIPTION
Right now, django-rest-swagger is failing with this error:

```python

Traceback:  

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/django/views/generic/base.py" in view
  68.             return self.dispatch(request, *args, **kwargs)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/views.py" in dispatch
  505.             response = self.handle_exception(exc)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/views.py" in handle_exception
  465.             self.raise_uncaught_exception(exc)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/views.py" in raise_uncaught_exception
  476.         raise exc

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/views.py" in dispatch
  502.             response = handler(request, *args, **kwargs)

File "/edx/app/analytics_api/analytics_api/analyticsdataserver/views.py" in get
  50.         return Response(generator.get_schema())

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/schemas/coreapi.py" in get_schema
  156.         links = self.get_links(None if public else request)

File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.5/site-packages/rest_framework/schemas/coreapi.py" in get_links
  143.             link = view.schema.get_link(path, method, base_url=self.url)

Exception Type: AttributeError at /docs/
Exception Value: 'AutoSchema' object has no attribute 'get_link'
```
This change is taken from this [link](https://stackoverflow.com/questions/57654243/how-to-fix-attributeerror-at-api-doc-autoschema-object-has-no-attribute-ge) and solves this particular problem

This is on the DRF docs https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi

### NOTE: 
We can solve this problem if we instead migrate to drf-yasg/edx-api-doc-tools (https://github.com/edx/edx-analytics-data-api/pull/329), the problem is that right now edx-api-doc-tools is only creating the documentation for the /api/ endpoints

## Reviewers
- [ ] @andrey-canon
- [ ] @jmbowman 
- [x] Ready for edX review
