### PR TITLE
Updated Python and Django in Travis and Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-python:
-  - 3.5
+
 branches:
   only:
     - master
@@ -23,21 +22,26 @@ script:
 
 matrix:
   include:
-    - env:
-        TESTNAME=quality
-        TARGETS="quality"
-    - env:
-        TESTNAME=test-python
-        TARGETS="test"
+    - python: 3.5
+      env:
+        TESTNAME=quality-python-3.5
+        TARGETS="PYTHON_ENV=py35 quality"
+    - python: 3.5
+      env:
+        TESTNAME=test-python-3.5
+        TARGETS="PYTHON_ENV=py35 test"
       after_success:
         - docker exec analytics_api_testing /edx/app/analytics_api/analytics_api/.travis/run_coverage.sh
         - codecov --disable pycov
-    - env:
-        TESTNAME=test-python-django20
-        TARGETS="DJANGO_VERSION=django20 test"
-    - env:
-        TESTNAME=test-python-django21
-        TARGETS="DJANGO_VERSION=django21 test"
-    - env:
-        TESTNAME=test-python-django111
-        TARGETS="DJANGO_VERSION=django111 test"
+
+    - python: 3.8
+      env:
+        TESTNAME=quality-python-3.8
+        TARGETS="PYTHON_ENV=py38 quality"
+    - python: 3.8
+      env:
+        TESTNAME=test-python-3.8
+        TARGETS="PYTHON_ENV=py38 test"
+
+  allow_failures:
+    - python: 3.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,10 +17,10 @@ django-cors-headers==3.2.1  # via -r requirements/base.in
 django-countries==6.1.2   # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via edx-enterprise-data
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, edx-enterprise-data, edx-rbac
+django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-ccx-keys==1.0.1       # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
 edx-enterprise-data==2.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.1.2           # via edx-enterprise-data
+edx-rbac==1.1.3           # via edx-enterprise-data
 edx-rest-api-client==5.1.0  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -43,7 +43,7 @@ jinja2==2.11.2            # via coreschema
 jmespath==0.9.5           # via boto3, botocore
 markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==3.1.1        # via -r requirements/base.in
 pbr==5.4.5                # via stevedore
@@ -63,11 +63,11 @@ rules==2.2                # via edx-enterprise-data
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
+six==1.14.0               # via cryptography, django-waffle, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.43.0              # via -r requirements/base.in
+tqdm==4.45.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.9           # via -r requirements/base.in, elasticsearch, requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,23 +13,11 @@
 # Use latest Django LTS version
 Django>=2.2,<2.3.0
 
-# django-model-utils version 4.0.0 dropped support to python 2.7	
-django-model-utils<4.0.0	
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9                 # BSD
-
-# django-waffle version 0.19.0 dropped support to Django 2.0 and 2.1, see https://github.com/django-waffle/django-waffle/blob/master/CHANGES
-django-waffle<0.19.0
 
 # django22 tests are failing. Constraint taken from https://github.com/edx/edx-drf-extensions version 5.0.2
 drf-jwt<1.15.0
 
 # elasticsearch-dsl depends on elasticsearch >2.0.0,<3.0.0
 elasticsearch-dsl<2.0.0
-
-# gunicorn version 20.0.0 dropped support to Python 2.7
-gunicorn<20.0.0
-
-# mysqlclient>1.4.6 dropped support to Python 2.7
-mysqlclient==1.4.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,10 +17,10 @@ django-cors-headers==3.2.1  # via -r requirements/base.in
 django-countries==6.1.2   # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via edx-enterprise-data
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, edx-enterprise-data, edx-rbac
+django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-ccx-keys==1.0.1       # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
 edx-enterprise-data==2.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.1.2           # via edx-enterprise-data
+edx-rbac==1.1.3           # via edx-enterprise-data
 edx-rest-api-client==5.1.0  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -43,7 +43,7 @@ jinja2==2.11.2            # via coreschema
 jmespath==0.9.5           # via boto3, botocore
 markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==3.1.1        # via -r requirements/base.in
 pbr==5.4.5                # via stevedore
@@ -63,11 +63,11 @@ rules==2.2                # via edx-enterprise-data
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
+six==1.14.0               # via cryptography, django-waffle, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.43.0              # via -r requirements/base.in
+tqdm==4.45.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.9           # via -r requirements/base.in, elasticsearch, requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,10 +17,10 @@ django-cors-headers==3.2.1  # via -r requirements/base.in
 django-countries==6.1.2   # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via edx-enterprise-data
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, edx-enterprise-data, edx-rbac
+django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore, sphinx
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-ccx-keys==1.0.1       # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
 edx-enterprise-data==2.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.1.2           # via edx-enterprise-data
+edx-rbac==1.1.3           # via edx-enterprise-data
 edx-rest-api-client==5.1.0  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -43,7 +43,7 @@ jinja2==2.11.2            # via coreschema, sphinx
 jmespath==0.9.5           # via boto3, botocore
 markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==3.1.1        # via -r requirements/base.in
 pbr==5.4.5                # via stevedore
@@ -64,12 +64,12 @@ rules==2.2                # via edx-enterprise-data
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
+six==1.14.0               # via cryptography, django-waffle, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 sphinx==1.2.1             # via -r requirements/doc.in
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.43.0              # via -r requirements/base.in
+tqdm==4.45.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.9           # via -r requirements/base.in, elasticsearch, requests

--- a/requirements/pip_tools.in
+++ b/requirements/pip_tools.in
@@ -1,3 +1,3 @@
 # Dependencies to run compile tools
-pip-tools                           # Contains pip-compile, used to generate pip requirements files
-six                         
+pip-tools<5.0.0                           # Contains pip-compile, used to generate pip requirements files
+six

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,10 +17,10 @@ django-cors-headers==3.2.1  # via -r requirements/base.in
 django-countries==6.1.2   # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-fernet-fields==0.6  # via edx-enterprise-data
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, edx-enterprise-data, edx-rbac
+django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-fernet-fields, django-model-utils, django-storages, djangorestframework, drf-jwt, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-enterprise-data, edx-rbac, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
@@ -28,26 +28,26 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-ccx-keys==1.0.1       # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
 edx-enterprise-data==2.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.1.2           # via edx-enterprise-data
+edx-rbac==1.1.3           # via edx-enterprise-data
 edx-rest-api-client==5.1.0  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
 future==0.18.2            # via pyjwkest
 gevent==1.5.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
-gunicorn==19.10.0         # via -c requirements/constraints.txt, -r requirements/production.in
+gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via requests
 itypes==1.1.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jmespath==0.9.5           # via boto3, botocore
 markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
-mysqlclient==1.4.6        # via -c requirements/constraints.txt, -r requirements/production.in
-newrelic==5.10.0.138      # via -r requirements/production.in, edx-django-utils
+mysqlclient==1.4.6        # via -r requirements/production.in
+newrelic==5.12.0.140      # via -r requirements/production.in, edx-django-utils
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==3.1.1        # via -r requirements/base.in
 path.py==8.2.1            # via -r requirements/production.in
@@ -68,11 +68,12 @@ rules==2.2                # via edx-enterprise-data
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
+six==1.14.0               # via cryptography, django-waffle, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, pyjwkest, python-dateutil, python-memcached, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.43.0              # via -r requirements/base.in
+tqdm==4.45.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.9           # via -r requirements/base.in, elasticsearch, requests
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,21 +23,21 @@ django-countries==6.1.2   # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-fernet-fields==0.6  # via edx-enterprise-data
-django-model-utils==3.2.0  # via -c requirements/constraints.txt, edx-enterprise-data, edx-rbac
+django-model-utils==3.2.0  # via edx-enterprise-data, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-ccx-keys==1.0.1       # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
-edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.2.1   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
 edx-enterprise-data==2.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.1.2           # via edx-enterprise-data
+edx-rbac==1.1.3           # via edx-enterprise-data
 edx-rest-api-client==5.1.0  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -55,7 +55,7 @@ markdown==2.6.6           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 more-itertools==8.2.0     # via pytest
-newrelic==5.10.0.138      # via edx-django-utils
+newrelic==5.12.0.140      # via edx-django-utils
 openapi-codec==1.3.2      # via django-rest-swagger
 ordered-set==3.1.1        # via -r requirements/base.in
 packaging==20.3           # via pytest
@@ -88,16 +88,16 @@ rules==2.2                # via edx-enterprise-data
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via astroid, cryptography, diff-cover, django-dynamic-fixture, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, packaging, pathlib2, pyjwkest, python-dateutil, python-memcached, responses, stevedore
+six==1.14.0               # via astroid, cryptography, diff-cover, django-dynamic-fixture, django-waffle, djangorestframework-csv, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise-data, edx-opaque-keys, edx-rbac, elasticsearch-dsl, packaging, pathlib2, pyjwkest, python-dateutil, python-memcached, responses, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.43.0              # via -r requirements/base.in
+tqdm==4.45.0              # via -r requirements/base.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.9           # via -r requirements/base.in, elasticsearch, requests
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -17,5 +17,5 @@ six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in
 tox==3.14.6               # via -r requirements/tox.in, tox-battery
-virtualenv==20.0.17       # via tox
+virtualenv==20.0.18       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -10,4 +10,4 @@ codecov==2.0.22           # via -r requirements/travis.in
 coverage==5.1             # via codecov
 idna==2.9                 # via requests
 requests==2.23.0          # via codecov
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 skipsdist=True
-envlist = {py35}-django{111,20,21,22}-{check_isort,pycodestyle,pylint,isort,tests}
+envlist = py{35,38}-django{22,30}-{check_isort,pycodestyle,pylint,isort,tests}
 
 [testenv]
 envdir=
     # Use the same environment for all commands running under a specific python version
     py35: {toxworkdir}/py35
+    py38: {toxworkdir}/py38
 
 passenv =
-    ELASTICSEARCH_LEARNERS_HOST 
+    ELASTICSEARCH_LEARNERS_HOST
     COVERAGE_DIR
 
 setenv =
@@ -17,10 +18,8 @@ setenv =
     PATH = $PATH:$NODE_BIN
 
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: -r requirements/django.txt
+    django30: Django>=3.0,<3.1
     -r requirements/test.txt
 
 commands =


### PR DESCRIPTION
**Issue:** [BOM-1530](https://openedx.atlassian.net/browse/BOM-1530)

### Description
- Added `python3.8` and `django3.0` in tox.
- Removed `django111`, `django2.0` and `django2.1` from Travis.
- Added `python3.8` in Travis.