### PR TITLE
Revert "[BD] Move to tox"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,3 @@ commands =
     tests: python -Wd -m pytest {posargs}
     coverage: coverage html
     coverage: coverage xml
-    generate_fake_course_data: python manage.py generate_fake_course_data {posargs}
-    loaddata: python manage.py loaddata problem_response_answer_distribution --database=analytics
-    migrate: python manage.py migrate --noinput {posargs}
-    set_api_key: python manage.py set_api_key edx edx
-    static: python manage.py collectstatic --noinput 


### PR DESCRIPTION
Reverts edx/edx-analytics-data-api#358

https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/30100/console

```
Specifically the create api users task is running /edx/app/analytics_api/venvs/analytics_api/bin/python manage.py 
set_api_key dummy-api-user changeme and failing with 
MySQLdb._exceptions.ProgrammingError: 
(1146, \"Table 'analytics-api.auth_user' doesn't exist\") which seems to indicate that migrations haven't run.
```