### PR TITLE
Upgrade requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,34 +6,39 @@ ELASTICSEARCH_VERSION = 1.5.2
 ELASTICSEARCH_PORT = 9223
 PYTHON_ENV=py35
 DJANGO_VERSION=django22
+.DEFAULT_GOAL := help
+
+help: ## display this help message
+	@echo "Please use \`make <target>' where <target> is one of"
+	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: requirements develop clean diff.report view.diff.report quality static
 
-requirements:
+requirements:  ## install base requirements
 	pip3 install -q -r requirements/base.txt
 
-production-requirements:
+production-requirements:  ## install production requirements
 	pip3 install -r requirements.txt
 
-test.install_elasticsearch:
+test.install_elasticsearch:  ## install elasticsearch
 	curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$(ELASTICSEARCH_VERSION).zip
 	unzip elasticsearch-$(ELASTICSEARCH_VERSION).zip
 	echo "http.port: $(ELASTICSEARCH_PORT)" >> elasticsearch-$(ELASTICSEARCH_VERSION)/config/elasticsearch.yml
 
-test.run_elasticsearch:
+test.run_elasticsearch:  ## run elasticsearch
 	cd elasticsearch-$(ELASTICSEARCH_VERSION) && ./bin/elasticsearch -d --http.port=$(ELASTICSEARCH_PORT)
 
-test.requirements: requirements
+test.requirements: requirements  ## install base and test requirements
 	pip3 install -q -r requirements/test.txt
 
-tox.requirements:
+tox.requirements:  ## install tox requirements
 	 pip3 install -q -r requirements/tox.txt
 
-develop: test.requirements
+develop: test.requirements  ## install test and dev requirements
 	pip3 install -q -r requirements/dev.txt
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade:  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip3 install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
@@ -52,66 +57,66 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	    requirements/test.txt \
 	    requirements/tox.txt \
 	    requirements/travis.txt
-	# Let tox control the Django version for tests
+	## Let tox control the Django version for tests
 	grep -e "^django==" requirements/base.txt > requirements/django.txt
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 
 
-clean: tox.requirements
+clean: tox.requirements  ## install tox requirements and run tox clean. Delete *.pyc files
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-clean
 	find . -name '*.pyc' -delete
 
-test: tox.requirements clean
-	if [ -e elasticsearch-$(ELASTICSEARCH_VERSION) ]; then curl --silent --head http://localhost:$(ELASTICSEARCH_PORT)/roster_test > /dev/null || make test.run_elasticsearch; fi  # Launch ES if installed and not running
+test: tox.requirements clean  ## install tox requirements, run tox clean. Install elasticsearch and run tests. Run coverage report.
+	if [ -e elasticsearch-$(ELASTICSEARCH_VERSION) ]; then curl --silent --head http://localhost:$(ELASTICSEARCH_PORT)/roster_test > /dev/null || make test.run_elasticsearch; fi  ## Launch ES if installed and not running
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-tests
 	export COVERAGE_DIR=$(COVERAGE_DIR) && \
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-coverage
 
-diff.report: test.requirements
+diff.report: test.requirements  ## Show the diff in quality and coverage
 	diff-cover $(COVERAGE_DIR)/coverage.xml --html-report $(COVERAGE_DIR)/diff_cover.html
 	diff-quality --violations=pycodestyle --html-report $(COVERAGE_DIR)/diff_quality_pycodestyle.html
 	diff-quality --violations=pylint --html-report $(COVERAGE_DIR)/diff_quality_pylint.html
 
-view.diff.report:
+view.diff.report:  ## Show the diff in quality and coverage using xdg
 	xdg-open file:///$(COVERAGE_DIR)/diff_cover.html
 	xdg-open file:///$(COVERAGE_DIR)/diff_quality_pycodestyle.html
 	xdg-open file:///$(COVERAGE_DIR)/diff_quality_pylint.html
 
-run_check_isort: tox.requirements
+run_check_isort: tox.requirements  ## Run tox check_isort. (Installs tox requirements.)
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-check_isort
 
-run_pycodestyle: tox.requirements
+run_pycodestyle: tox.requirements  ## Run tox pycodestyle. (Installs tox requirements.)
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-pycodestyle
 
-run_pylint: tox.requirements
+run_pylint: tox.requirements  ## Run tox pylint. (Installs tox requirements.)
 	tox -e $(PYTHON_ENV)-$(DJANGO_VERSION)-pylint
 
-run_isort: tox.requirements
+run_isort: tox.requirements  ## Run tox isort. (Installs tox requirements.)
 	tox -e  $(PYTHON_ENV)-$(DJANGO_VERSION)-isort
 
-quality: tox.requirements run_pylint run_check_isort run_pycodestyle
+quality: tox.requirements run_pylint run_check_isort run_pycodestyle  ## run_pylint, run_check_isort, run_pycodestyle (Installs tox requirements.)
 
-validate: test.requirements test quality
+validate: test.requirements test quality  ## Runs make test and make quality. (Installs test requirements.)
 
-static:
+static:  ## Runs collectstatic
 	python manage.py collectstatic --noinput
 
-migrate:
+migrate:  ## Runs django migrations with syncdb and default database
 	./manage.py migrate --noinput --run-syncdb --database=default
 
-migrate-all:
+migrate-all:  ## Runs migrations on all databases
 	$(foreach db_name,$(DATABASES),./manage.py migrate --noinput --run-syncdb --database=$(db_name);)
 
-loaddata: migrate
+loaddata: migrate  ## Runs migrations and generates fake data
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
 	python manage.py generate_fake_course_data
 
-demo: clean requirements loaddata
+demo: clean requirements loaddata  ## Runs make clean, requirements, and loaddata, sets api key to edx
 	python manage.py set_api_key edx edx
 
 # Target used by edx-analytics-dashboard during its testing.
-travis: clean test.requirements migrate-all
+travis: clean test.requirements migrate-all  ## Used by travis for testing
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
 	python manage.py generate_fake_course_data --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-boto3==1.14.23            # via -r requirements/base.in
+boto3==1.14.31            # via -r requirements/base.in
 boto==2.42.0              # via -r requirements/base.in
-botocore==1.17.23         # via boto3, s3transfer
+botocore==1.17.31         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
-edx-enterprise-data==2.1.0  # via -r requirements/base.in
+edx-enterprise-data==2.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.3.1           # via edx-enterprise-data
+edx-rbac==1.3.2           # via edx-enterprise-data
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -70,4 +70,4 @@ stevedore==1.32.0         # via edx-opaque-keys
 tqdm==4.48.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.10          # via -r requirements/base.in, botocore, elasticsearch, requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-boto3==1.14.23            # via -r requirements/base.in
+boto3==1.14.31            # via -r requirements/base.in
 boto==2.42.0              # via -r requirements/base.in
-botocore==1.17.23         # via boto3, s3transfer
+botocore==1.17.31         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
-edx-enterprise-data==2.1.0  # via -r requirements/base.in
+edx-enterprise-data==2.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.3.1           # via edx-enterprise-data
+edx-rbac==1.3.2           # via edx-enterprise-data
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -70,4 +70,4 @@ stevedore==1.32.0         # via edx-opaque-keys
 tqdm==4.48.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.10          # via -r requirements/base.in, botocore, elasticsearch, requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-boto3==1.14.23            # via -r requirements/base.in
+boto3==1.14.31            # via -r requirements/base.in
 boto==2.42.0              # via -r requirements/base.in
-botocore==1.17.23         # via boto3, s3transfer
+botocore==1.17.31         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore, sphinx
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
-edx-enterprise-data==2.1.0  # via -r requirements/base.in
+edx-enterprise-data==2.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.3.1           # via edx-enterprise-data
+edx-rbac==1.3.2           # via edx-enterprise-data
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -72,4 +72,4 @@ stevedore==1.32.0         # via edx-opaque-keys
 tqdm==4.48.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.10          # via -r requirements/base.in, botocore, elasticsearch, requests

--- a/requirements/pip_tools.in
+++ b/requirements/pip_tools.in
@@ -1,3 +1,3 @@
 # Dependencies to run compile tools
-pip-tools<5.0.0                           # Contains pip-compile, used to generate pip requirements files
+pip-tools>5.0.0                           # Contains pip-compile, used to generate pip requirements files
 six

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip_tools.in
+pip-tools==5.3.0          # via -r requirements/pip_tools.in
 six==1.15.0               # via -r requirements/pip_tools.in, pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-boto3==1.14.23            # via -r requirements/base.in
+boto3==1.14.31            # via -r requirements/base.in
 boto==2.42.0              # via -r requirements/base.in
-botocore==1.17.23         # via boto3, s3transfer
+botocore==1.17.31         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -28,11 +28,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
-edx-enterprise-data==2.1.0  # via -r requirements/base.in
+edx-enterprise-data==2.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.3.1           # via edx-enterprise-data
+edx-rbac==1.3.2           # via edx-enterprise-data
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -75,7 +75,7 @@ stevedore==1.32.0         # via edx-opaque-keys
 tqdm==4.48.0              # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via -r requirements/base.in, botocore, elasticsearch, requests
+urllib3==1.25.10          # via -r requirements/base.in, botocore, elasticsearch, requests
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,11 +6,11 @@
 #
 astroid==2.3.3            # via pylint
 attrs==19.3.0             # via pytest
-boto3==1.14.23            # via -r requirements/base.in
+boto3==1.14.31            # via -r requirements/base.in
 boto==2.42.0              # via -r requirements/base.in
-botocore==1.17.23         # via boto3, s3transfer
+botocore==1.17.31         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -33,11 +33,11 @@ docutils==0.15.2          # via botocore
 drf-jwt==1.16.2           # via edx-drf-extensions
 edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
+edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions, edx-enterprise-data, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-enterprise-data, edx-rbac
-edx-enterprise-data==2.1.0  # via -r requirements/base.in
+edx-enterprise-data==2.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions, edx-enterprise-data
-edx-rbac==1.3.1           # via edx-enterprise-data
+edx-rbac==1.3.2           # via edx-enterprise-data
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-enterprise-data
 elasticsearch-dsl==0.0.11  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via elasticsearch-dsl
@@ -45,6 +45,7 @@ future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via inflect, pluggy, pytest
 inflect==3.0.2            # via jinja2-pluralize
+iniconfig==1.0.0          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -76,7 +77,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
+pytest==6.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions, elasticsearch-dsl
 python-memcached==1.59    # via -r requirements/base.in
 pytz==2020.1              # via -r requirements/test.in, django
@@ -93,11 +94,11 @@ slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
+toml==0.10.1              # via pytest
 tqdm==4.48.0              # via -r requirements/base.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.9           # via -r requirements/base.in, botocore, elasticsearch, requests
-wcwidth==0.2.5            # via pytest
+urllib3==1.25.10          # via -r requirements/base.in, botocore, elasticsearch, requests
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -17,5 +17,5 @@ six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
 tox==3.14.6               # via -c requirements/constraints.txt, -r requirements/tox.in, tox-battery
-virtualenv==20.0.27       # via tox
+virtualenv==20.0.28       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 codecov==2.1.8            # via -r requirements/travis.in
-coverage==5.2             # via codecov
+coverage==5.2.1           # via codecov
 idna==2.10                # via requests
 requests==2.24.0          # via codecov
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests


### PR DESCRIPTION
Upgrades requirements.

I did not include the major version upgrade to cryptography, as it contains breaking changes.

Also creates a `make help` command as the default make command and adds docstrings to the makefile.