### PR TITLE
change python_env in makefile to 38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGES = analyticsdataserver analytics_data_api
 DATABASES = default analytics
 ELASTICSEARCH_VERSION = 1.5.2
 ELASTICSEARCH_PORT = 9223
-PYTHON_ENV=py35
+PYTHON_ENV=py38
 DJANGO_VERSION=django22
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
This repo was recently updated to run on Python3.8, but it looks like something was missed. This change only impacts testing related Make targets, which were causing the edx-analytics-dashboard CI to fail.