### PR TITLE
Specify a default yaml loader

### DIFF
--- a/analyticsdataserver/settings/production.py
+++ b/analyticsdataserver/settings/production.py
@@ -31,7 +31,7 @@ ALLOWED_HOSTS = ['*']
 CONFIG_FILE=get_env_setting('ANALYTICS_API_CFG')
 
 with open(CONFIG_FILE) as f:
-  config_from_yaml = yaml.load(f)
+  config_from_yaml = yaml.load(f, Loader=yaml.FullLoader)
 
 REPORT_DOWNLOAD_BACKEND = config_from_yaml.pop('REPORT_DOWNLOAD_BACKEND', {})
 


### PR DESCRIPTION
Yaml loads must now specify a default Loader parameter. 

See test deploy here: https://gocd.tools.edx.org/go/tab/build/detail/stage-analyticsapi/235/run_play/1/prod_edx