### PR TITLE
BOM-2247 - Upgrade pip-tools

### DIFF
--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,9 +4,16 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip_tools.in
-six==1.15.0               # via -r requirements/pip_tools.in
+click==8.0.1
+    # via pip-tools
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
+    # via -r requirements/pip_tools.in
+six==1.16.0
+    # via -r requirements/pip_tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Now that we are have pinned pip to version 20.3.4 in configuration, which is compatible with the latest version of pip-tools according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

So in this PR, we are upgrading the latest pip-tools.

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247