### PR TITLE
test: Adding test to check jwt encode and decode methods.

### DIFF
--- a/analytics_data_api/tests/test_jwt.py
+++ b/analytics_data_api/tests/test_jwt.py
@@ -1,0 +1,26 @@
+from time import time
+
+import jwt
+from django.test import TestCase
+
+
+class JWTSanityTest(TestCase):
+    """ Test for the JWT sanity check."""
+    def test_encode_decode(self):
+        """
+        This test ensure  jwt.encode and jwt.decode are working properly.
+        """
+        now = int(time())
+        payload = {
+            "iss": 'test-issue',
+            "aud": 'test-audience',
+            "exp": now + 10,
+            "iat": now,
+            "username": 'staff',
+            "email": 'staff@example.com',
+        }
+        secret = 'test-secret'
+        jwt_message = jwt.encode(payload, secret)
+        decoded_payload = jwt.decode(jwt_message, secret, verify=False)
+
+        assert payload == decoded_payload


### PR DESCRIPTION
Jwt new version `v2.0.0` has some [breaking changes](https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-errors), this test will help to identify any issues before deployment.

Just checking encode and decodes works with params. We already saw few prod failures, this might help us little bit.

Verified this test against `v2.1.0` in this [PR](https://github.com/edx/edx-analytics-data-api/pull/469) and it is failing there.