### PR TITLE
[Fix] Pin the version of elasticsearch library to < 7.14.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.18.18
+boto3==1.18.21
     # via -r requirements/base.in
-botocore==1.21.18
+botocore==1.21.21
     # via
     #   boto3
     #   s3transfer
@@ -100,7 +100,7 @@ edx-drf-extensions==7.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==2.2.19
+edx-enterprise-data==2.2.20
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
@@ -114,8 +114,10 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-elasticsearch==7.14.0
-    # via elasticsearch-dsl
+elasticsearch==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,9 @@
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9                 # BSD
 
+# elasticsearch library cannot be greater than 7.14.0. 7.14.0 library is not compatible with the 7.10 server in stage and prod
+elasticsearch < 7.14.0
+
 # elasticsearch-dsl depends on elasticsearch >=7.8.0,<8.0.0
 elasticsearch-dsl>=7.2.1,<8.0.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,9 +6,9 @@
 #
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.18.18
+boto3==1.18.21
     # via -r requirements/base.in
-botocore==1.21.18
+botocore==1.21.21
     # via
     #   boto3
     #   s3transfer
@@ -100,7 +100,7 @@ edx-drf-extensions==7.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==2.2.19
+edx-enterprise-data==2.2.20
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
@@ -114,8 +114,10 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-elasticsearch==7.14.0
-    # via elasticsearch-dsl
+elasticsearch==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,9 +10,9 @@ babel==2.9.1
     # via sphinx
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.18.18
+boto3==1.18.21
     # via -r requirements/base.in
-botocore==1.21.18
+botocore==1.21.21
     # via
     #   boto3
     #   s3transfer
@@ -106,7 +106,7 @@ edx-drf-extensions==7.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==2.2.19
+edx-enterprise-data==2.2.20
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
@@ -122,8 +122,10 @@ edx-rest-api-client==5.4.0
     #   edx-enterprise-data
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-elasticsearch==7.14.0
-    # via elasticsearch-dsl
+elasticsearch==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,9 +6,9 @@
 #
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.18.18
+boto3==1.18.21
     # via -r requirements/base.in
-botocore==1.21.18
+botocore==1.21.21
     # via
     #   boto3
     #   s3transfer
@@ -100,7 +100,7 @@ edx-drf-extensions==7.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==2.2.19
+edx-enterprise-data==2.2.20
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
@@ -114,8 +114,10 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-elasticsearch==7.14.0
-    # via elasticsearch-dsl
+elasticsearch==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,9 +10,9 @@ attrs==21.2.0
     # via pytest
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.18.18
+boto3==1.18.21
     # via -r requirements/base.in
-botocore==1.21.18
+botocore==1.21.21
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ cryptography==3.4.7
     #   pyjwt
 ddt==1.4.2
     # via -r requirements/test.in
-diff-cover==6.2.2
+diff-cover==6.3.0
     # via -r requirements/test.in
     # via
     #   -c requirements/common_constraints.txt
@@ -115,7 +115,7 @@ edx-drf-extensions==7.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==2.2.19
+edx-enterprise-data==2.2.20
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
@@ -129,8 +129,10 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-elasticsearch==7.14.0
-    # via elasticsearch-dsl
+elasticsearch==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
@@ -281,8 +283,6 @@ toml==0.10.2
     # via
     #   pytest
     #   pytest-cov
-tomli==1.2.1
-    # via diff-cover
 tqdm==4.62.0
     # via -r requirements/base.in
 unicodecsv==0.14.1


### PR DESCRIPTION
Apparently, 7.14.0 library is not compatible with ES 7.10 server in prod

@edx/masters-devs-cosmonauts Please help review.