### PR TITLE
fix: ES search should return all matches, not only 10

### DIFF
--- a/analytics_data_api/v0/documents.py
+++ b/analytics_data_api/v0/documents.py
@@ -160,7 +160,12 @@ class RosterEntry(Document):
             }
             for sort_policy in sort_policies
         ])
-        return search_request.execute()
+
+        # calling count will generate an additional request to ES, but is necessary for returning the entire set of data
+        total = search_request.count()
+        # by default, ES will only return the first 10 documents, we want to get all of them
+        total_search_requests = search_request[0:total]
+        return total_search_requests.execute()
 
     @classmethod
     def get_course_metadata(cls, course_id):


### PR DESCRIPTION
## [MST-1033](https://openedx.atlassian.net/browse/MST-1033)

Elasticsearch queries were only returning 10 matches, as opposed to the entire query set. I believe this change occurred during a requirements upgrade in which elasticsearch-dsl was ugraded to version 7.4.0. 

Tests did not catch this behavior change because the testing for pagination created a set of 6 learners, meaning that an ES search query matching that entire set of learners would work as expected. Once the set of learners increases above 10, the test for pagination fails. 

I have updated the relevant ES code to return all matching documents, as opposed to 10, and also updated the pagination test.