### PR TITLE
fix: have elasticsearch return all items

### DIFF
--- a/analytics_data_api/v0/documents.py
+++ b/analytics_data_api/v0/documents.py
@@ -160,7 +160,9 @@ class RosterEntry(Document):
             }
             for sort_policy in sort_policies
         ])
-        return search_request.execute()
+
+        # scan returns a generator, but we want to return a list.
+        return list(search_request.params(preserve_order=True).scan())
 
     @classmethod
     def get_course_metadata(cls, course_id):


### PR DESCRIPTION
ES searches are only returning 10 results when we use `execute`. We tried to return the total amount of documents using execute here https://github.com/edx/edx-analytics-data-api/pull/484, but courses with more than 10,000 learners would error out due to the result window being too large. 

Scan does not have this same limitation, however, it may cause memory pressure. I believe that this PR would at least cause the behavior of the learner endpoint to be consistent with its performance pre ES/ES-dsl library upgrade.