### PR TITLE
Fix: return first 10000 matches from ES search

### DIFF
--- a/analytics_data_api/v0/documents.py
+++ b/analytics_data_api/v0/documents.py
@@ -160,7 +160,14 @@ class RosterEntry(Document):
             }
             for sort_policy in sort_policies
         ])
-        return search_request.execute()
+
+        # by default, ES will only return the first 10 documents, we want to get as many as possible
+        count = search_request.count()
+        if count > 10000:
+            logger.info('Cannot return more than 10,000 learners for course_id=%s', course_id)
+            count = 10000
+        total_search_requests = search_request[0:count]
+        return total_search_requests.execute()
 
     @classmethod
     def get_course_metadata(cls, course_id):


### PR DESCRIPTION
ES is currently only returning 10 documents per search, which is not ideal. If we try to increase the scope of the search to include all matching documents, endpoints using ES will error if there are more than 10,000 matches. First attempt at fixing here: https://github.com/edx/edx-analytics-data-api/pull/484

I also tried to change from using `execute` to `scan` here https://github.com/edx/edx-analytics-data-api/pull/486, but this was causing a transport error: 
`File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.8/site-packages/elasticsearch/connection/base.py", line 330, in _raise_error
    raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
elasticsearch.exceptions.TransportError: TransportError(406, 'Content-Type header [application/x-www-form-urlencoded; charset=UTF-8] is not supported', 'Content-Type header [application/x-www-form-urlencoded; charset=UTF-8] is not supported')`.

For this attempt, we are simply limiting search to 10,000 documents, so that the bug is partially fixed (better than nothing, right?). There is a follow-up ticket to determine an actual fix for paginating requests to ES.