### PR TITLE
feat: use new database for v1 api

### DIFF
--- a/analytics_data_api/urls.py
+++ b/analytics_data_api/urls.py
@@ -5,6 +5,7 @@ app_name = 'analytics_data_api'
 
 urlpatterns = [
     url(r'^v0/', include('analytics_data_api.v0.urls')),
+    url(r'^v1/', include('analytics_data_api.v1.urls')),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/analytics_data_api/v1/urls.py
+++ b/analytics_data_api/v1/urls.py
@@ -1,0 +1,5 @@
+from ..v0.urls import urlpatterns as v0_urlpatterns
+
+app_name = 'v1'
+
+urlpatterns = v0_urlpatterns.copy()

--- a/analyticsdataserver/router.py
+++ b/analyticsdataserver/router.py
@@ -1,15 +1,17 @@
+import threading
+
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
-import threading
-
 request_cfg = threading.local()
 
+
 class RouterMiddleware(MiddlewareMixin):
-    def process_view(self, request, view_func, args, kwargs):
+    def process_view(self, request):
         if 'api/v1' in request.path:
             request_cfg.database = getattr(settings, 'ANALYTICS_DATABASE_V1', 'default_v1')
-    def process_response(self, request, response):
+
+    def process_response(self, request, response):  # pylint: disable=unused-argument
         if hasattr(request_cfg, 'database'):
             del request_cfg.database
         return response
@@ -24,8 +26,7 @@ class AnalyticsApiRouter:
         if app_label in ('v1', 'v0', 'enterprise_data'):
             if hasattr(request_cfg, 'database'):
                 return request_cfg.database
-            else:
-                return getattr(settings, 'ANALYTICS_DATABASE', 'default')
+            return getattr(settings, 'ANALYTICS_DATABASE', 'default')
 
         return None
 

--- a/analyticsdataserver/router.py
+++ b/analyticsdataserver/router.py
@@ -7,7 +7,7 @@ request_cfg = threading.local()
 
 
 class RouterMiddleware(MiddlewareMixin):
-    def process_view(self, request):
+    def process_view(self, request, view_func, args, kwargs):  # pylint: disable=unused-argument
         if 'api/v1' in request.path:
             request_cfg.database = getattr(settings, 'ANALYTICS_DATABASE_V1', 'default_v1')
 

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -60,6 +60,15 @@ DATABASES = {
         'USER': 'api001',
         'ATOMIC_REQUESTS': False,
     },
+    'reports_v1': {
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'localhost',
+        'NAME': 'reports_v1',
+        'OPTIONS': DEFAULT_MYSQL_OPTIONS,
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'reports001',
+    },
     'reports': {
         'ENGINE': 'django.db.backends.mysql',
         'HOST': 'localhost',
@@ -212,6 +221,7 @@ MIDDLEWARE = [
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    'analyticsdataserver.router.RouterMiddleware',
     'analytics_data_api.v0.middleware.LearnerEngagementTimelineNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.LearnerNotFoundErrorMiddleware',
     'analytics_data_api.v0.middleware.CourseNotSpecifiedErrorMiddleware',
@@ -370,7 +380,8 @@ REST_FRAMEWORK = {
 
 ########## ANALYTICS DATA API CONFIGURATION
 
-ANALYTICS_DATABASE = 'default'
+ANALYTICS_DATABASE = 'reports'
+ANALYTICS_DATABASE_V1 = 'reports_v1'
 DATABASE_ROUTERS = ['analyticsdataserver.router.AnalyticsApiRouter']
 ENTERPRISE_REPORTING_DB_ALIAS = 'enterprise'
 

--- a/analyticsdataserver/settings/devstack.py
+++ b/analyticsdataserver/settings/devstack.py
@@ -14,6 +14,14 @@ DATABASES = {
         'HOST': 'edx.devstack.mysql',
         'PORT': '3306',
     },
+    'analytics_v1': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'reports_v1',
+        'USER': 'api001',
+        'PASSWORD': 'password',
+        'HOST': 'edx.devstack.mysql',
+        'PORT': '3306',
+    },
     'analytics': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'reports',
@@ -34,6 +42,7 @@ DB_OVERRIDES = dict(
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
     DATABASES['analytics'][override] = value
+    DATABASES['analytics_v1'][override] = value
 ########## END DATABASE CONFIGURATION
 
 ELASTICSEARCH_LEARNERS_HOST = os.environ.get('ELASTICSEARCH_LEARNERS_HOST', 'edx.devstack.elasticsearch')

--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -40,6 +40,14 @@ DATABASES = {
         'HOST': '',
         'PORT': '',
     },
+    'analytics_v1': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': normpath(join(DJANGO_ROOT, 'analytics.db')),
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    },
     'enterprise': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': normpath(join(DJANGO_ROOT, 'enterprise_reporting.db')),
@@ -66,6 +74,9 @@ CACHES = {
 
 ANALYTICS_DATABASE = 'analytics'
 ENTERPRISE_REPORTING_DB_ALIAS = 'analytics'
+# Requests to the /v1/ api will use this database.
+# To test a second database under the /v1/ routes change this to 'analytics_v1'
+ANALYTICS_DATABASE_V1 = 'analytics'
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -16,6 +16,10 @@ DATABASES = {
     },
 }
 
+ANALYTICS_DATABASE = 'default'
+ENTERPRISE_REPORTING_DB_ALIAS = 'default'
+ANALYTICS_DATABASE_V1 = 'default'
+
 # Silence elasticsearch during tests
 LOGGING['loggers']['elasticsearch']['handlers'] = ['null']
 


### PR DESCRIPTION
Adds an empty v1 api that includes all of the v0 urls and by extension views. Requests made to the v1 api will have any database queries routed to a different database.

This requires a bit of trickery because the typical database router only knows about the model it is querying and nothing about the request context. This adds a request middleware step to evaluate the path for a v1 url and store the new DB parameter on the thread where it can be referenced inside the db router.

Still thinking on it but I'm not seeing a good way to unit test this.


Open to suggestions if there is a less-scary way to do this...


@edx/masters-devs-cosmonauts 

https://openedx.atlassian.net/browse/MST-1113
https://openedx.atlassian.net/browse/MST-1112

