### PR TITLE
feat: v1 api urls

### DIFF
--- a/analytics_data_api/urls.py
+++ b/analytics_data_api/urls.py
@@ -5,6 +5,7 @@ app_name = 'analytics_data_api'
 
 urlpatterns = [
     url(r'^v0/', include('analytics_data_api.v0.urls')),
+    url(r'^v1/', include('analytics_data_api.v1.urls')),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/analytics_data_api/v1/urls.py
+++ b/analytics_data_api/v1/urls.py
@@ -1,0 +1,5 @@
+from ..v0.urls import urlpatterns as v0_urlpatterns
+
+app_name = 'v1'
+
+urlpatterns = v0_urlpatterns.copy()

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -60,6 +60,15 @@ DATABASES = {
         'USER': 'api001',
         'ATOMIC_REQUESTS': False,
     },
+    'reports_v1': {
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'localhost',
+        'NAME': 'reports_v1',
+        'OPTIONS': DEFAULT_MYSQL_OPTIONS,
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'reports001',
+    },
     'reports': {
         'ENGINE': 'django.db.backends.mysql',
         'HOST': 'localhost',
@@ -370,7 +379,9 @@ REST_FRAMEWORK = {
 
 ########## ANALYTICS DATA API CONFIGURATION
 
-ANALYTICS_DATABASE = 'default'
+ANALYTICS_DATABASE = 'reports'
+# Currently unused, V1 database will support migration to new backend data source
+ANALYTICS_DATABASE_V1 = 'reports_v1'
 DATABASE_ROUTERS = ['analyticsdataserver.router.AnalyticsApiRouter']
 ENTERPRISE_REPORTING_DB_ALIAS = 'enterprise'
 

--- a/analyticsdataserver/settings/devstack.py
+++ b/analyticsdataserver/settings/devstack.py
@@ -14,6 +14,14 @@ DATABASES = {
         'HOST': 'edx.devstack.mysql',
         'PORT': '3306',
     },
+    'analytics_v1': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'reports_v1',
+        'USER': 'api001',
+        'PASSWORD': 'password',
+        'HOST': 'edx.devstack.mysql',
+        'PORT': '3306',
+    },
     'analytics': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'reports',
@@ -34,6 +42,7 @@ DB_OVERRIDES = dict(
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
     DATABASES['analytics'][override] = value
+    DATABASES['analytics_v1'][override] = value
 ########## END DATABASE CONFIGURATION
 
 ELASTICSEARCH_LEARNERS_HOST = os.environ.get('ELASTICSEARCH_LEARNERS_HOST', 'edx.devstack.elasticsearch')

--- a/analyticsdataserver/settings/local.py
+++ b/analyticsdataserver/settings/local.py
@@ -40,6 +40,14 @@ DATABASES = {
         'HOST': '',
         'PORT': '',
     },
+    'analytics_v1': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': normpath(join(DJANGO_ROOT, 'analytics.db')),
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    },
     'enterprise': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': normpath(join(DJANGO_ROOT, 'enterprise_reporting.db')),
@@ -66,6 +74,7 @@ CACHES = {
 
 ANALYTICS_DATABASE = 'analytics'
 ENTERPRISE_REPORTING_DB_ALIAS = 'analytics'
+ANALYTICS_DATABASE_V1 = 'analytics'
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -16,6 +16,10 @@ DATABASES = {
     },
 }
 
+ANALYTICS_DATABASE = 'default'
+ENTERPRISE_REPORTING_DB_ALIAS = 'default'
+ANALYTICS_DATABASE_V1 = 'default'
+
 # Silence elasticsearch during tests
 LOGGING['loggers']['elasticsearch']['handlers'] = ['null']
 


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

Adds a new set of V1 API URLs that will be incrementally built out to use a new data source. Currently they just fall back to the V0 views if not implemented.

Also adds configuration for a second database that will be supporting this new API. Currently, that database is unused.

https://openedx.atlassian.net/browse/MST-1113