### PR TITLE
[MST-1230] Make ANALYTICS_DATABASE_V1 Testable in Devstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT = $(shell echo "$$PWD")
 COVERAGE_DIR = $(ROOT)/build/coverage
-DATABASES = default analytics
+DATABASES = default analytics analytics_v1
 .DEFAULT_GOAL := help
 
 TOX=''
@@ -113,9 +113,11 @@ migrate:  ## Runs django migrations with syncdb and default database
 migrate-all:  ## Runs migrations on all databases
 	$(foreach db_name,$(DATABASES),./manage.py migrate --noinput --run-syncdb --database=$(db_name);)
 
-loaddata: migrate  ## Runs migrations and generates fake data
+loaddata: migrate-all  ## Runs migrations and generates fake data
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
-	python manage.py generate_fake_course_data
+	python manage.py loaddata problem_response_answer_distribution_analytics_v1 --database=analytics_v1
+	python manage.py generate_fake_course_data --database=analytics
+	python manage.py generate_fake_course_data --database=analytics_v1
 
 create_indices:  ## Create ElasticSearch indices
 	python manage.py create_elasticsearch_learners_indices

--- a/analytics_data_api/fixtures/problem_response_answer_distribution_analytics_v1.json
+++ b/analytics_data_api/fixtures/problem_response_answer_distribution_analytics_v1.json
@@ -1,0 +1,274 @@
+[
+    {
+        "fields": {
+            "answer_value": "36.02736",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "EarthSciences/GP202/Spring2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://EarthSciences/GP202/problem/d50bf059fa05468e94f61d52dd37f228",
+            "part_id": "i4x-EarthSciences-GP202-problem-d50bf059fa05468e94f61d52dd37f228_4_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Earth Science Question",
+            "question_text": "Enter your answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "answer_value": "33.0",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "EarthSciences/GP202/Spring2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://EarthSciences/GP202/problem/d50bf059fa05468e94f61d52dd37f228",
+            "part_id": "i4x-EarthSciences-GP202-problem-d50bf059fa05468e94f61d52dd37f228_4_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Earth Science Question",
+            "question_text": "Enter your answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "answer_value": "27.51936482",
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "EarthSciences/GP202/Spring2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://EarthSciences/GP202/problem/d50bf059fa05468e94f61d52dd37f228",
+            "part_id": "i4x-EarthSciences-GP202-problem-d50bf059fa05468e94f61d52dd37f228_4_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Earth Science Question",
+            "question_text": "Enter your answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "answer_value": "28.65",
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "EarthSciences/GP202/Spring2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://EarthSciences/GP202/problem/d50bf059fa05468e94f61d52dd37f228",
+            "part_id": "i4x-EarthSciences-GP202-problem-d50bf059fa05468e94f61d52dd37f228_4_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Earth Science Question",
+            "question_text": "Enter your answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "answer_value": "line 15: mean(glm.pred==Direction)",
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 190,
+            "course_id": "HumanitiesScience/StatLearning/Winter2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://HumanitiesScience/StatLearning/problem/3c53e173c9af464aa3afb8fac82c3702",
+            "part_id": "i4x-HumanitiesScience-StatLearning-problem-3c53e173c9af464aa3afb8fac82c3702_2_1",
+            "value_id": "choice_0",
+            "variant": null,
+            "problem_display_name": null,
+            "question_text": null
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "answer_value": "line 22: Direction.2005=Smarket$Direction[!train]",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "HumanitiesScience/StatLearning/Winter2014",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://HumanitiesScience/StatLearning/problem/3c53e173c9af464aa3afb8fac82c3702",
+            "part_id": "i4x-HumanitiesScience-StatLearning-problem-3c53e173c9af464aa3afb8fac82c3702_2_1",
+            "value_id": "choice_2",
+            "variant": null,
+            "problem_display_name": null,
+            "question_text": null
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 6
+    },
+    {
+        "fields": {
+            "answer_value": "line 30: table(glm.pred,Direction.2005)",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 2,
+            "course_id": "HumanitiesScience/StatLearning/Winter2014",
+            "created": "2014-06-24T17:13:12",
+            "module_id": "i4x://HumanitiesScience/StatLearning/problem/3c53e173c9af464aa3afb8fac82c3702",
+            "part_id": "i4x-HumanitiesScience-StatLearning-problem-3c53e173c9af464aa3afb8fac82c3702_2_1",
+            "value_id": "choice_3",
+            "variant": null,
+            "problem_display_name": null,
+            "question_text": null
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 7
+    },
+    {
+        "fields": {
+            "answer_value": "5.02",
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 190,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_2_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Enter an answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 8
+    },
+    {
+        "fields": {
+            "answer_value": "62",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 26,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_2_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Enter an answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 9
+    },
+    {
+        "fields": {
+            "answer_value": "10.2",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 200,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:12",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_2_1",
+            "value_id": null,
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Enter an answer:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 10
+    },
+    {
+        "fields": {
+            "answer_value": null,
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 10,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_3_1",
+            "value_id": null,
+            "variant": 2,
+            "problem_display_name": "Example problem",
+            "question_text": "Randomized answer"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 11
+    },
+    {
+        "fields": {
+            "answer_value": null,
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 426,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_3_1",
+            "value_id": null,
+            "variant": 100,
+            "problem_display_name": "Example problem",
+            "question_text": "Randomized answer"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 12
+    },
+
+    {
+        "fields": {
+            "answer_value": "North America",
+            "correct": true,
+            "first_response_count": 0,
+            "last_response_count": 190,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_4_1",
+            "value_id": "choice_0",
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Select from the choices below:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 13
+    },
+    {
+        "fields": {
+            "answer_value": "Africa",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 26,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:11",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_4_1",
+            "value_id": "choice_0",
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Select from the choices below:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 14
+    },
+    {
+        "fields": {
+            "answer_value": "Asia",
+            "correct": false,
+            "first_response_count": 0,
+            "last_response_count": 200,
+            "course_id": "edX/DemoX/Demo_Course",
+            "created": "2014-06-24T17:13:12",
+            "module_id": "i4x://edX/DemoX.1/problem/05d289c5ad3d47d48a77622c4a81ec36",
+            "part_id": "i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec33_4_1",
+            "value_id": "choice_0",
+            "variant": null,
+            "problem_display_name": "Example problem",
+            "question_text": "Select from the choices below:"
+        },
+        "model": "v0.problemfirstlastresponseanswerdistribution",
+        "pk": 15
+    }
+
+]

--- a/analytics_data_api/management/commands/tests/test_generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/tests/test_generate_fake_course_data.py
@@ -1,9 +1,11 @@
 from django.core.management import call_command
 from django.test import TestCase
 
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models
 
 
+@set_databases
 class GenerateFakeCourseDataTests(TestCase):
     def testNormalRun(self):
         num_weeks = 2
@@ -13,7 +15,8 @@ class GenerateFakeCourseDataTests(TestCase):
             'generate_fake_course_data',
             f"--num-weeks={num_weeks}",
             "--no-videos",
-            "--course-id", course_id
+            "--course-id", course_id,
+            "--database", 'analytics',
         )
 
         for model in [models.CourseEnrollmentDaily,

--- a/analytics_data_api/middleware.py
+++ b/analytics_data_api/middleware.py
@@ -22,7 +22,7 @@ thread_data = local()
 class RequestVersionMiddleware:
     """
     Add a database hint, analyticsapi_database, in the form of an attribute in thread-local storage.
-    This is used by the AnalyticsApiRouter to switch databases between the v0 and v1 views.
+    This is used by the AnalyticsAPIRouter to switch databases between the v0 and v1 views.
     """
     def __init__(self, get_response):
         self.get_response = get_response

--- a/analytics_data_api/tests/test_middleware.py
+++ b/analytics_data_api/tests/test_middleware.py
@@ -1,17 +1,30 @@
+from unittest import mock
+
 from django.conf import settings
 from django.test import override_settings
 
 from analytics_data_api.middleware import thread_data
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0.tests.views import CourseSamples
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
+@set_databases
 class RequestVersionMiddleware(TestCaseWithAuthentication):
     def test_request_version_middleware_v1(self):
-        self.authenticated_get('/api/v1/courses/{}/activity'.format(
-            CourseSamples.course_ids[0]))
+        # Because the AnalyticsModelsRouter prevents migrations from running on the ANALYTICS_DATABASE_V1
+        # database, and the AnalyticsDevelopmentRouter is not configured to be used in the test environment,
+        # the analytics tables don't exist in the ANALYTICS_DATABASE_V1 database. This causes errors like
+        # "django.db.utils.OperationalError: no such table: course_activity" to be thrown when the
+        # CourseActivityWeeklyView view is run. Therefore, we mock out the get_queryset method, because all we care
+        # about is the middleware correctly setting the analyticsapi_database attribute of the thread local data
+        # correctly.
+        with mock.patch('analytics_data_api.v0.views.courses.CourseActivityWeeklyView.get_queryset') as qs:
+            qs.return_value = None
+            self.authenticated_get('/api/v1/courses/{}/activity'.format(
+                CourseSamples.course_ids[0]))
 
-        self.assertEqual(thread_data.analyticsapi_database, getattr(settings, 'ANALYTICS_DATABASE_V1'))
+            self.assertEqual(thread_data.analyticsapi_database, getattr(settings, 'ANALYTICS_DATABASE_V1'))
 
     @override_settings(ANALYTICS_DATABASE_V1=None)
     def test_request_version_middleware_v1_no_setting(self):
@@ -24,4 +37,4 @@ class RequestVersionMiddleware(TestCaseWithAuthentication):
         self.authenticated_get('/api/v0/courses/{}/activity'.format(
             CourseSamples.course_ids[0]))
 
-        self.assertEqual("default", getattr(thread_data, 'analyticsapi_database'))
+        self.assertEqual("analytics", getattr(thread_data, 'analyticsapi_database'))

--- a/analytics_data_api/tests/test_utils.py
+++ b/analytics_data_api/tests/test_utils.py
@@ -119,3 +119,15 @@ class DateRangeTests(TestCase):
             datetime.datetime(2016, 1, 3),
             datetime.datetime(2016, 1, 4),
         ])
+
+
+def set_databases(cls):
+    """
+    This is to be used as a class decorator to set the databases
+    test class attribute to ensure that all databases are flushed.
+    Please see https://docs.djangoproject.com/en/3.2/topics/testing/tools/#multi-database-support.
+    """
+    def wrapper(cls):
+        setattr(cls, 'databases', '__all__')
+        return cls
+    return wrapper(cls)

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -2,9 +2,11 @@ from django.test import TestCase
 from django_dynamic_fixture import G
 
 from analytics_data_api.constants.country import UNKNOWN_COUNTRY, get_country
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models
 
 
+@set_databases
 class CourseEnrollmentByCountryTests(TestCase):
     def test_country(self):
         country = get_country('US')

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -3,6 +3,7 @@ from datetime import date
 from django.test import TestCase
 from django_dynamic_fixture import G
 
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models as api_models
 from analytics_data_api.v0 import serializers as api_serializers
 
@@ -11,6 +12,7 @@ class TestSerializer(api_serializers.CourseEnrollmentDailySerializer, api_serial
     pass
 
 
+@set_databases
 class DynamicFieldsModelSerializerTests(TestCase):
     def test_fields(self):
         now = date.today()

--- a/analytics_data_api/v0/tests/test_urls.py
+++ b/analytics_data_api/v0/tests/test_urls.py
@@ -1,7 +1,10 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from analytics_data_api.tests.test_utils import set_databases
 
+
+@set_databases
 class UrlRedirectTests(TestCase):
     api_root_path = '/api/v0/'
 

--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -7,12 +7,14 @@ from django.utils import timezone
 from django_dynamic_fixture import G
 
 from analytics_data_api.constants import enrollment_modes
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.tests.views import APIListViewTestMixin, CourseSamples, VerifyCourseIdMixin
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
 @ddt.ddt
+@set_databases
 class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseMetaSummaryEnrollment
     model_id = 'course_id'

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -26,6 +26,7 @@ from analytics_data_api.constants.engagement_events import (
     VIDEO,
     VIEWED,
 )
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.utils import get_filename_safe_course_id
 from analytics_data_api.v0 import models
 from analytics_data_api.v0.tests.utils import create_engagement
@@ -51,6 +52,7 @@ class DefaultFillTestMixin:
 
 # pylint: disable=no-member
 @ddt.ddt
+@set_databases
 class CourseViewTestCaseMixin(VerifyCsvResponseMixin):
     model = None
     api_root_path = '/api/v0/'
@@ -156,6 +158,7 @@ class CourseViewTestCaseMixin(VerifyCsvResponseMixin):
 
 # pylint: disable=abstract-method
 @ddt.ddt
+@set_databases
 class CourseEnrollmentViewTestCaseMixin(CourseViewTestCaseMixin):
     date = None
 
@@ -175,6 +178,7 @@ class CourseEnrollmentViewTestCaseMixin(CourseViewTestCaseMixin):
 
 
 @ddt.ddt
+@set_databases
 class CourseActivityLastWeekTest(TestCaseWithAuthentication):
     def generate_data(self, course_id):
         interval_start = datetime.datetime(2014, 1, 1, tzinfo=pytz.utc)
@@ -272,6 +276,7 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
 
 
 @ddt.ddt
+@set_databases
 class CourseEnrollmentByBirthYearViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithAuthentication):
     path = '/enrollment/birth_year'
     model = models.CourseEnrollmentByBirthYear
@@ -301,6 +306,7 @@ class CourseEnrollmentByBirthYearViewTests(CourseEnrollmentViewTestCaseMixin, Te
         self.assertEqual(response.data, expected)
 
 
+@set_databases
 class CourseEnrollmentByEducationViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithAuthentication):
     path = '/enrollment/education/'
     model = models.CourseEnrollmentByEducation
@@ -327,6 +333,7 @@ class CourseEnrollmentByEducationViewTests(CourseEnrollmentViewTestCaseMixin, Te
 
 
 @ddt.ddt
+@set_databases
 class CourseEnrollmentByGenderViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFillTestMixin,
                                         TestCaseWithAuthentication):
     path = '/enrollment/gender/'
@@ -389,6 +396,7 @@ class CourseEnrollmentByGenderViewTests(CourseEnrollmentViewTestCaseMixin, Defau
         self.assertViewReturnsExpectedData([expected], course_id)
 
 
+@set_databases
 class CourseEnrollmentViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithAuthentication):
     model = models.CourseEnrollmentDaily
     path = '/enrollment'
@@ -407,6 +415,7 @@ class CourseEnrollmentViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithA
 
 
 @ddt.ddt
+@set_databases
 class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFillTestMixin,
                                     TestCaseWithAuthentication):
     model = models.CourseEnrollmentModeDaily
@@ -467,6 +476,7 @@ class CourseEnrollmentModeViewTests(CourseEnrollmentViewTestCaseMixin, DefaultFi
         self.assertViewReturnsExpectedData([expected], course_id)
 
 
+@set_databases
 class CourseEnrollmentByLocationViewTests(CourseEnrollmentViewTestCaseMixin, TestCaseWithAuthentication):
     path = '/enrollment/location/'
     model = models.CourseEnrollmentByCountry
@@ -514,6 +524,7 @@ class CourseEnrollmentByLocationViewTests(CourseEnrollmentViewTestCaseMixin, Tes
 
 
 @ddt.ddt
+@set_databases
 class CourseActivityWeeklyViewTests(CourseViewTestCaseMixin, TestCaseWithAuthentication):
     path = '/activity/'
     default_order_by = 'interval_end'
@@ -587,6 +598,7 @@ class CourseActivityWeeklyViewTests(CourseViewTestCaseMixin, TestCaseWithAuthent
 
 
 @ddt.ddt
+@set_databases
 class CourseProblemsListViewTests(TestCaseWithAuthentication):
     def _get_data(self, course_id):
         """
@@ -650,6 +662,7 @@ class CourseProblemsListViewTests(TestCaseWithAuthentication):
 
 
 @ddt.ddt
+@set_databases
 class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
     def _get_data(self, course_id):
         """
@@ -729,6 +742,7 @@ class CourseProblemsAndTagsListViewTests(TestCaseWithAuthentication):
 
 
 @ddt.ddt
+@set_databases
 class CourseVideosListViewTests(TestCaseWithAuthentication):
     def _get_data(self, course_id):
         """
@@ -787,8 +801,8 @@ class CourseVideosListViewTests(TestCaseWithAuthentication):
 
 
 @ddt.ddt
+@set_databases
 class UserEngagementViewTests(TestCaseWithAuthentication):
-
     def _get_data(self, course_id):
         """
         Retrieve intervention report a specified course.
@@ -866,8 +880,8 @@ class UserEngagementViewTests(TestCaseWithAuthentication):
 
 
 @ddt.ddt
+@set_databases
 class CourseReportDownloadViewTests(TestCaseWithAuthentication):
-
     path = '/api/v0/courses/{course_id}/reports/{report_name}'
 
     @patch('django.core.files.storage.default_storage.exists', Mock(return_value=False))

--- a/analytics_data_api/v0/tests/views/test_engagement_timelines.py
+++ b/analytics_data_api/v0/tests/views/test_engagement_timelines.py
@@ -15,12 +15,14 @@ from analytics_data_api.constants.engagement_events import (
     VIDEO,
     VIEWED,
 )
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0.tests.utils import create_engagement
 from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
 @ddt.ddt
+@set_databases
 class EngagementTimelineTests(VerifyCourseIdMixin, TestCaseWithAuthentication):
     DEFAULT_USERNAME = 'ed_xavier'
     path_template = '/api/v0/engagement_timelines/{}/?course_id={}'

--- a/analytics_data_api/v0/tests/views/test_enterprise_learner_engagements.py
+++ b/analytics_data_api/v0/tests/views/test_enterprise_learner_engagements.py
@@ -11,6 +11,7 @@ from analytics_data_api.constants.engagement_events import (
     VIDEO,
     VIEWED,
 )
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0.tests.utils import create_engagement, create_enterprise_user
 from analytics_data_api.v0.tests.views import CourseSamples
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
@@ -53,6 +54,7 @@ PAGINATED_SAMPLE_DATA = [
 
 
 @ddt.ddt
+@set_databases
 class EnterpriseLearnerEngagementViewTests(TestCaseWithAuthentication):
     @classmethod
     def setUpClass(cls):

--- a/analytics_data_api/v0/tests/views/test_learners.py
+++ b/analytics_data_api/v0/tests/views/test_learners.py
@@ -14,6 +14,7 @@ from rest_framework import status
 from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from analytics_data_api.constants import engagement_events
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0.models import ModuleEngagementMetricRanges
 from analytics_data_api.v0.tests.views import CourseSamples, VerifyCourseIdMixin, VerifyCsvResponseMixin
 from analytics_data_api.v0.views import CsvViewMixin, PaginatedHeadersMixin
@@ -644,11 +645,11 @@ class LearnerCsvListTests(LearnerAPITestMixin, VerifyCourseIdMixin,
 
 
 @ddt.ddt
+@set_databases
 class CourseLearnerMetadataTests(VerifyCourseIdMixin, LearnerAPITestMixin, TestCaseWithAuthentication,):
     """
     Tests for the course learner metadata endpoint.
     """
-
     def _get(self, course_id):
         """Helper to send a GET request to the API."""
         return self.authenticated_get(f'/api/v0/course_learner_metadata/{course_id}/')

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -8,6 +8,7 @@ import json
 
 from django_dynamic_fixture import G
 
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models
 from analytics_data_api.v0.serializers import (
     GradeDistributionSerializer,
@@ -17,6 +18,7 @@ from analytics_data_api.v0.serializers import (
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
+@set_databases
 class AnswerDistributionTests(TestCaseWithAuthentication):
     path = '/answer_distribution/'
     maxDiff = None
@@ -138,6 +140,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         self.assertEqual(response.status_code, 404)
 
 
+@set_databases
 class GradeDistributionTests(TestCaseWithAuthentication):
     path = '/grade_distribution/'
     maxDiff = None
@@ -167,6 +170,7 @@ class GradeDistributionTests(TestCaseWithAuthentication):
         self.assertEqual(response.status_code, 404)
 
 
+@set_databases
 class SequentialOpenDistributionTests(TestCaseWithAuthentication):
     path = '/sequential_open_distribution/'
     maxDiff = None

--- a/analytics_data_api/v0/tests/views/test_programs.py
+++ b/analytics_data_api/v0/tests/views/test_programs.py
@@ -3,12 +3,14 @@ import datetime
 import ddt
 from django_dynamic_fixture import G
 
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models, serializers
 from analytics_data_api.v0.tests.views import APIListViewTestMixin, CourseSamples
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
 @ddt.ddt
+@set_databases
 class ProgramsViewTests(TestCaseWithAuthentication, APIListViewTestMixin):
     model = models.CourseProgramMetadata
     model_id = 'program_id'

--- a/analytics_data_api/v0/tests/views/test_videos.py
+++ b/analytics_data_api/v0/tests/views/test_videos.py
@@ -4,12 +4,13 @@ from django.conf import settings
 from django.utils import timezone
 from django_dynamic_fixture import G
 
+from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
+@set_databases
 class VideoTimelineTests(TestCaseWithAuthentication):
-
     def _get_data(self, video_id=None):
         return self.authenticated_get(f'/api/v0/videos/{video_id}/timeline')
 

--- a/analyticsdataserver/router.py
+++ b/analyticsdataserver/router.py
@@ -1,29 +1,126 @@
+# This file contains database routers used for routing database operations to the appropriate databases.
+# Below is a digest of the routers in this file.
+# AnalyticsDevelopmentRouter: This router routes database operations in a development environment. Currently, it only
+#                             effects migrations. For example, in development, we want to be able to migrate the
+#                             v0 and v1 apps into the v0 and v1 databases, respectively.
+# AnalyticsAPIRouter: This router routes database operations based on the version of the analytics data API being used.
+#                     It allows us to route database traffic to the v1 database when using the v1 API, for example.
+# AnalyticsModelsRouter: This router routes database operations based on the model that is being requested.
+#
+# The DATABASE_ROUTERS Django setting defines what database routers are used and in what order in a given environment.
+#
+# Note that if a database router returns None for a router method or does not implement the method, the master router
+# delegates to the next router in the list until a value is returned. The master router falls back to a default behavior
+# if no custom router returns a value.
+
 from django.conf import settings
 
 from analytics_data_api.middleware import thread_data
 
+ANALYTICS_APP_LABELS = ['v0', 'v1', 'enterprise_data']
 
-class AnalyticsApiRouter:
-    def db_for_read(self, model, **hints):  # pylint: disable=unused-argument
-        # pylint: disable=protected-access
+
+class AnalyticsDevelopmentRouter:
+    """
+    This router's role is to route database operations in the development environment. It is meant, in part, to simulate
+    the way databases are structured in the production environment. For example, the ANALYTICS_DATABASE
+    and ANALYTICS_DATABASE_V1 databases in production do not contain models from "non-analytics" apps,
+    like the auth app. This is because said databases are populated by other means (e.g. EMR jobs, prefect flows).
+    Therefore, we attempt to only allow these apps to be migrated where necessary; see inline comment for more details.
+
+    This router also ensures that analytics apps are not migrated into the default database unless the default
+    database is the only configured database.
+
+    This router also handles an edge case with the enterprise_data app and the ANALYTICS_DATABASE_V1 database;
+    see inline comment for more details.
+    """
+    # pylint: disable=unused-argument
+    def allow_migrate(self, database, app_label, model_name=None, **hints):
+        if app_label in ANALYTICS_APP_LABELS:
+            databases = getattr(settings, 'DATABASES').keys()
+            # We don't want to migrate enterprise_data into the ANALYTICS_DATABASE_V1 database. The reason is two-fold.
+            # 1) The ANALYTICS_DATABASE_V1 tables in production do not include enterprise_data tables.
+            # 2) The migration 0018_enterprisedatafeaturerole_enterprisedataroleassignment in the enterprise_data app
+            #    creates models. When running migrations on the v1 database, this migration successfully creates those
+            #    models in the v1 database. The migration 0019_add_enterprise_data_feature_roles creates model instances
+            #    for those models created in the previous migration. The write process triggers the db_for_write method
+            #    of Django routers. The db_for_write method returns the value of
+            #    getattr(settings, 'ANALYTICS_DATABASE', 'default'), which writes the data to the wrong database. There
+            #    is no straight forward way to force the db_for_write method to return the value of
+            #    getattr(settings, 'ANALYTICS_DATABASE_V1') instead. We forgo migrating that app entirely
+            #    in this database.
+            if app_label == 'enterprise_data' and database == getattr(settings, 'ANALYTICS_DATABASE_V1'):
+                return False
+
+            # If the requested database for migrations is the default database, but other analytics
+            # databases are set up, they should be favored over the default database, so prevent these
+            # migrations from being run on the default database.
+            # We only allow migrations on analytics application models on the default database when analytics
+            # is not set up.
+            if database == 'default' and 'default' in databases and len(databases) > 1:
+                return False
+
+            return True
+
+        # Ideally, we'd only want to migrate other applications into the default database to better
+        # mimic production. However, the enterprise_data application has the migration
+        # 0018_enterprisedatafeaturerole_enterprisedataroleassignment, which creates a model with a ForeignKey field
+        # pointing to the auth_user model. MySQL does not allow cross-database relations, because they violate
+        # referential integrity, so we cannot only migrate auth_user into the default database.
+        # For that reason, we need to allow the migration of the auth_user table into the ANALYTICS_DATABASE
+        # as well.
+        # Please see https://docs.djangoproject.com/en/3.2/topics/db/multi-db/#limitations-of-multiple-databases.
+        return database in ['default', getattr(settings, 'ANALYTICS_DATABASE')]
+
+
+class AnalyticsAPIRouter:
+    """
+    This router's role is to route database operations to the appropriate database when there is an 'analytics_database'
+    "hint" in the local thread data. This "hint" is set by the RequestVersionMiddleware and is meant to route
+    database operations to particular databases depending on the version of the API requested via the view.
+    """
+    def _get_database(self, app_label):
+        if app_label in ANALYTICS_APP_LABELS and hasattr(thread_data, 'analyticsapi_database'):
+            return getattr(thread_data, 'analyticsapi_database')
+        # If there is no analyticsapi_database database hint, then fall back to next router.
+        return None
+
+    # pylint: disable=unused-argument
+    # pylint: disable=protected-access
+    def db_for_read(self, model, **hints):
         return self._get_database(model._meta.app_label)
 
+    # pylint: disable=unused-argument
+    # pylint: disable=protected-access
+    def db_for_write(self, model, **hints):
+        return self._get_database(model._meta.app_label)
+
+
+class AnalyticsModelsRouter:
+    """
+    This router's role is to route database operations for all other database operations.
+
+    We do not define an allow_relation method. We fall back to Django's default behavior, which is to allow relations
+    between model instances that were loaded from the same database.
+    """
+
     def _get_database(self, app_label):
-        if app_label in ('v0', 'v1', 'enterprise_data'):
-            if hasattr(thread_data, 'analyticsapi_database'):
-                return getattr(thread_data, 'analyticsapi_database')
+        if app_label in ANALYTICS_APP_LABELS:
             return getattr(settings, 'ANALYTICS_DATABASE', 'default')
         return None
 
-    def db_for_write(self, model, **hints):  # pylint: disable=unused-argument
-        # pylint: disable=protected-access
+    # pylint: disable=unused-argument
+    # pylint: disable=protected-access
+    def db_for_read(self, model, **hints):
         return self._get_database(model._meta.app_label)
 
-    def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=unused-argument
-        # pylint: disable=protected-access
-        return self._get_database(obj1._meta.app_label) == self._get_database(obj2._meta.app_label)
+    # pylint: disable=unused-argument
+    # pylint: disable=protected-access
+    def db_for_write(self, model, **hints):
+        return self._get_database(model._meta.app_label)
 
-    def allow_migrate(self, database, app_label, model_name=None, **hints):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def allow_migrate(self, database, app_label, model_name=None, **hints):
         dest_db = self._get_database(app_label)
         if dest_db is not None:
             return database == dest_db

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -383,7 +383,7 @@ REST_FRAMEWORK = {
 ANALYTICS_DATABASE = 'reports'
 # Currently unused, V1 database will support migration to new backend data source
 ANALYTICS_DATABASE_V1 = 'reports_v1'
-DATABASE_ROUTERS = ['analyticsdataserver.router.AnalyticsApiRouter']
+DATABASE_ROUTERS = ['analyticsdataserver.router.AnalyticsAPIRouter', 'analyticsdataserver.router.AnalyticsModelsRouter']
 ENTERPRISE_REPORTING_DB_ALIAS = 'enterprise'
 
 LMS_BASE_URL = None

--- a/analyticsdataserver/settings/devstack.py
+++ b/analyticsdataserver/settings/devstack.py
@@ -32,6 +32,8 @@ DATABASES = {
     }
 }
 
+ANALYTICS_DATABASE_V1 = 'analytics_v1'
+
 DB_OVERRIDES = dict(
     USER=os.environ.get('DB_USER', DATABASES['default']['USER']),
     PASSWORD=os.environ.get('DB_PASSWORD', DATABASES['default']['PASSWORD']),
@@ -43,6 +45,9 @@ for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
     DATABASES['analytics'][override] = value
     DATABASES['analytics_v1'][override] = value
+
+DATABASE_ROUTERS = ['analyticsdataserver.router.AnalyticsDevelopmentRouter', 'analyticsdataserver.router.AnalyticsAPIRouter', 'analyticsdataserver.router.AnalyticsModelsRouter']
+
 ########## END DATABASE CONFIGURATION
 
 ELASTICSEARCH_LEARNERS_HOST = os.environ.get('ELASTICSEARCH_LEARNERS_HOST', 'edx.devstack.elasticsearch')

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -14,11 +14,27 @@ DATABASES = {
         "HOST": "",
         "PORT": "",
     },
+    'analytics': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': normpath(join(DJANGO_ROOT, 'analytics.db')),
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    },
+    'analytics_v1': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': normpath(join(DJANGO_ROOT, 'analytics_v1.db')),
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    },
 }
 
-ANALYTICS_DATABASE = 'default'
+ANALYTICS_DATABASE = 'analytics'
+ANALYTICS_DATABASE_V1 = 'analytics_v1'
 ENTERPRISE_REPORTING_DB_ALIAS = 'default'
-ANALYTICS_DATABASE_V1 = 'default'
 
 # Silence elasticsearch during tests
 LOGGING['loggers']['elasticsearch']['handlers'] = ['null']

--- a/analyticsdataserver/tests/test_router.py
+++ b/analyticsdataserver/tests/test_router.py
@@ -1,27 +1,92 @@
-import logging
 import unittest.mock as mock
 
-from django.contrib.auth.models import User
-from django.test import TestCase
+import ddt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
 
-from analytics_data_api.v0.models import CourseEnrollmentByBirthYear, CourseEnrollmentDaily
-from analyticsdataserver.router import AnalyticsApiRouter
+from analytics_data_api.v0.models import CourseEnrollmentDaily
+from analyticsdataserver.router import AnalyticsAPIRouter, AnalyticsDevelopmentRouter, AnalyticsModelsRouter
 
 
-class AnalyticsApiRouterTests(TestCase):
+class AnalyticsAPIRouterTests(TestCase):
     def setUp(self):
-        self.router = AnalyticsApiRouter()
-
-    def test_allow_relation(self):
-        """
-        Relations should only be allowed for objects contained within the same database.
-        """
-        self.assertFalse(self.router.allow_relation(CourseEnrollmentDaily, User))
-        self.assertTrue(self.router.allow_relation(CourseEnrollmentDaily, CourseEnrollmentByBirthYear))
+        self.router = AnalyticsAPIRouter()
 
     @mock.patch.dict('analytics_data_api.middleware.thread_data.__dict__', {'analyticsapi_database': 'test'})
-    def test_db_for_read_thread_data_with_data(self):
+    def test_db_for_read_analytics_app_thread_data_with_data(self):
         self.assertEqual(self.router.db_for_read(CourseEnrollmentDaily), 'test')
 
-    def test_db_for_read_thread_data_without_data(self):
+    def test_db_for_read_analytics_app_thread_data_without_data(self):
+        self.assertEqual(self.router.db_for_read(CourseEnrollmentDaily), getattr(settings, 'ANALYTICS_DATABASE', 'analytics'))
+
+    @mock.patch.dict('analytics_data_api.middleware.thread_data.__dict__', {'analyticsapi_database': 'test'})
+    def test_db_for_read_analytics_app_thread_data_with_data(self):
+        self.assertEqual(self.router.db_for_read(get_user_model()), None)
+
+    def test_db_for_read_not_analytics_app_thread_data_without_data(self):
+        self.assertEqual(self.router.db_for_read(get_user_model()), None)
+
+
+class AnalyticsModelsRouterTests(TestCase):
+    def setUp(self):
+        self.router = AnalyticsModelsRouter()
+        self.analytics_database_slug = getattr(settings, 'ANALYTICS_DATABASE', 'analytics')
+
+    def test_db_for_read_analytics_app(self):
+        self.assertEqual(self.router.db_for_read(CourseEnrollmentDaily), self.analytics_database_slug)
+
+    @override_settings()
+    def test_db_for_read_analytics_app_no_setting(self):
+        del settings.ANALYTICS_DATABASE
         self.assertEqual(self.router.db_for_read(CourseEnrollmentDaily), 'default')
+
+    def test_db_for_read_not_analytics_app(self):
+        self.assertEqual(self.router.db_for_read(get_user_model()), None)
+
+    def test_db_for_write_analytics_app(self):
+        self.assertEqual(self.router.db_for_write(CourseEnrollmentDaily), self.analytics_database_slug)
+
+    @override_settings()
+    def test_db_for_write_analytics_app_no_setting(self):
+        del settings.ANALYTICS_DATABASE
+        self.assertEqual(self.router.db_for_write(CourseEnrollmentDaily), 'default')
+
+    def test_db_for_write_not_analytics_app(self):
+        self.assertEqual(self.router.db_for_write(get_user_model()), None)
+
+    def test_allow_migrate_not_analytics_app(self):
+        self.assertEqual(self.router.allow_migrate(self.analytics_database_slug, get_user_model()._meta.app_label), None)
+
+
+@ddt.ddt
+class AnalyticsDevelopmentRouterTests(TestCase):
+    """"
+    Note that it's not currently possible to test the case where the default database is the only configured database.
+    Databases are configured during Django internal initialization, which means modifying the DATABASES Django setting
+    from a test will not work as expected.
+    The Django docs explicitly caution against doing this: "We do not recommend altering the DATABASES setting."
+    Please see here: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#overriding-settings.
+    For this reason, coverage is incomplete.
+    """
+    def setUp(self):
+        self.router = AnalyticsDevelopmentRouter()
+
+    @ddt.data(
+        ('default', True),
+        (getattr(settings, 'ANALYTICS_DATABASE', 'analytics'), True),
+        (getattr(settings, 'ANALYTICS_DATABASE_V1', 'analytics_v1'), False),
+    )
+    @ddt.unpack
+    def test_allow_migrate_not_analytics_app(self, database, expected_allow_migrate):
+        self.assertEqual(self.router.allow_migrate(database, 'auth'), expected_allow_migrate)
+
+    @ddt.data(
+        (getattr(settings, 'ANALYTICS_DATABASE_V1', 'analytics_v1'), 'enterprise_data', False),
+        (getattr(settings, 'default', 'default'), 'v0', False),
+        (getattr(settings, 'ANALYTICS_DATABASE', 'analytics'), 'v0', True),
+        (getattr(settings, 'ANALYTICS_DATABASE_V1', 'analytics_v1'), 'v0', True),
+    )
+    @ddt.unpack
+    def test_allow_migrate_analytics_app_multiple_dbs(self, database, app_label, expected_allow_migrate):
+        self.assertEqual(self.router.allow_migrate(database, app_label), expected_allow_migrate)

--- a/analyticsdataserver/tests/test_views.py
+++ b/analyticsdataserver/tests/test_views.py
@@ -5,9 +5,11 @@ from django.conf import settings
 from django.db.utils import ConnectionHandler
 from django.test.utils import override_settings
 
+from analytics_data_api.tests.test_utils import set_databases
 from analyticsdataserver.tests.utils import TestCaseWithAuthentication
 
 
+@set_databases
 class OperationalEndpointsTest(TestCaseWithAuthentication):
     def test_status(self):
         response = self.client.get('/status', follow=True)


### PR DESCRIPTION
This change makes v1 of the Analytics Data API testable in devstack.

The changes include:
* modifying the generate_fake_course_data management command to accept a "database" option
* modifying the loaddata make target to run the generate_fake_course_data management command with the analytics_v1 database
* adding a new problem_response_answer_distribution_analytics_v1 JSON file and loading it as part of the loaddata make target
* adding a development specific Django router
* modifying Django settings in the based, development, and test environment to use the correct Django routers

When users of devstack run the loaddata make target, both the analytics and the analytics_v1 databases will be loaded with dummy data. The data will be different, so users will be able to verify differences in the APIs.