### PR TITLE
fix: strip unnecessary expensive ordering

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -61,7 +61,7 @@ class CourseEnrollmentModeDaily(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_mode_daily'
-        ordering = ('date', 'course_id', 'mode')
+        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'mode')]
 
 
@@ -100,7 +100,7 @@ class CourseEnrollmentByBirthYear(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_birth_year_daily'
-        ordering = ('date', 'course_id', 'birth_year')
+        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'birth_year')]
 
 
@@ -109,7 +109,7 @@ class CourseEnrollmentByEducation(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_education_level_daily'
-        ordering = ('date', 'course_id', 'education_level')
+        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'education_level')]
 
 
@@ -131,7 +131,7 @@ class CourseEnrollmentByGender(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_gender_daily'
-        ordering = ('date', 'course_id', 'gender')
+        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'gender')]
 
 
@@ -196,7 +196,7 @@ class CourseEnrollmentByCountry(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_location_current'
-        ordering = ('date', 'course_id', 'country_code')
+        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'country_code')]
 
 


### PR DESCRIPTION
Having more columns in the django official sort means we sort by them all the time. We do not index by these fields, usually we only index by course id and date which is the obvious data organization. The data API further processes these, in the case of gender and mode squashing different entries to a single date row, and Insights sorts them locally.

We can't entirely ditch sorting here without adding it in python because in processing course enrollment groupby(date, course_id) is usually used and that requires the initial list to be sorted by those keys as well. 

related to MST-1305