### PR TITLE
use explicit sort in python instead of sorting in DB

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -24,7 +24,6 @@ class CourseActivityWeekly(BaseCourseModel):
     class Meta(BaseCourseModel.Meta):
         db_table = 'course_activity'
         index_together = [['course_id', 'activity_type']]
-        ordering = ('interval_end', 'interval_start', 'course_id')
         get_latest_by = 'interval_end'
 
     interval_start = models.DateTimeField()
@@ -51,7 +50,6 @@ class BaseCourseEnrollment(BaseCourseModel):
 class CourseEnrollmentDaily(BaseCourseEnrollment):
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_daily'
-        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date',)]
 
 
@@ -61,7 +59,6 @@ class CourseEnrollmentModeDaily(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_mode_daily'
-        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'mode')]
 
 
@@ -100,7 +97,6 @@ class CourseEnrollmentByBirthYear(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_birth_year_daily'
-        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'birth_year')]
 
 
@@ -109,7 +105,6 @@ class CourseEnrollmentByEducation(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_education_level_daily'
-        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'education_level')]
 
 
@@ -131,7 +126,6 @@ class CourseEnrollmentByGender(BaseCourseEnrollment):
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_gender_daily'
-        ordering = ('date', 'course_id')
         unique_together = [('course_id', 'date', 'gender')]
 
 

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -158,6 +158,7 @@ class CourseActivityWeeklyView(BaseCourseView):
         """
         formatted_data = []
 
+        data = sorted(data, key=lambda x: (x.course_id, x.interval_start, x.interval_end))
         for key, group in groupby(data, lambda x: (x.course_id, x.interval_start, x.interval_end)):
             # Iterate over groups and create a single item with all activity types
             item = {
@@ -401,7 +402,9 @@ class CourseEnrollmentByGenderView(BaseCourseEnrollmentView):
         queryset = super().get_queryset()
         formatted_data = []
 
-        for key, group in groupby(queryset, lambda x: (x.course_id, x.date)):
+        items = queryset.all()
+        items = sorted(items, key=lambda x: (x.course_id, x.date))
+        for key, group in groupby(items, lambda x: (x.course_id, x.date)):
             # Iterate over groups and create a single item with gender data
             item = {
                 'course_id': key[0],
@@ -507,7 +510,9 @@ class CourseEnrollmentModeView(BaseCourseEnrollmentView):
         queryset = super().get_queryset()
         formatted_data = []
 
-        for key, group in groupby(queryset, lambda x: (x.course_id, x.date)):
+        items = queryset.all()
+        items = sorted(items, key=lambda x: (x.course_id, x.date))
+        for key, group in groupby(items, lambda x: (x.course_id, x.date)):
             item = {
                 'course_id': key[0],
                 'date': key[1],


### PR DESCRIPTION
This PR is a bit of a performance experiment. I don't think it will blow up insights, it may help significantly, it may not.

Sorting in mysql is more efficient using indices and we're seeing the production mysql use an index without date which means it then sorts using a less efficient method. Sometimes it writes data to disk to do the sort, so that just blows up everything. Behavior is better on the read only DB than competing on the write DB, but still not always where it should be.

All this data is in memory in the API so we can make python do the sort. Conceptually I'm also not a fan of models having an order separated from your query just because it causes this sort of invisible database load.

Not all models need sorting, only the ones that use groupby, so there's asymmetry between lines removed and added.

Location code is left alone for the moment because it is not causing trouble and there is more weird stuff going on in location sort and resort than I wanted to tackle for this experiment. I also left the meta/program models alone today.