### PR TITLE
fix: change github_ci Make target to use analytics_v1 database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ demo: requirements clean loaddata  ## Runs make clean, requirements, and loaddat
 github_ci: test.requirements clean migrate-all  ## Used by CI for testing
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
-	python manage.py generate_fake_course_data --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"
+	python manage.py generate_fake_course_data --database=analytics --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"
 
 docker_build:
 	docker build . -f Dockerfile -t openedx/analytics-data-api


### PR DESCRIPTION
This pull request changes the github_ci Make target to run the generate_fake_course_data management command with the analytics_v1 option instead of the default, which is the default database. Because we do not migrate v0 app tables into the default database during CI, the tables that the generate_fake_course_data management command tries to write into do not exist.