### PR TITLE
fix user activity casing

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -14,6 +14,13 @@ class BaseCourseModel(models.Model):
     course_id = models.CharField(db_index=True, max_length=255)
     created = models.DateTimeField(auto_now_add=True)
 
+    def course_id_key(self):
+        """
+        Version of the course_id suitable for grouping when the database
+        contains multiple casings of the course ID
+        """
+        return str.casefold(self.course_id)
+
     class Meta:
         abstract = True
 

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -4,6 +4,7 @@ from django_dynamic_fixture import G
 from analytics_data_api.constants.country import UNKNOWN_COUNTRY, get_country
 from analytics_data_api.tests.test_utils import set_databases
 from analytics_data_api.v0 import models
+from analytics_data_api.v0.models import BaseCourseModel
 
 
 @set_databases
@@ -26,3 +27,19 @@ class CourseEnrollmentByCountryTests(TestCase):
 
         instance = G(models.CourseEnrollmentByCountry, country_code='UNKNOWN')
         self.assertEqual(instance.country, UNKNOWN_COUNTRY)
+
+
+class BaseCourseModelTests(TestCase):
+    def test_courseid_key(self):
+        course = BaseCourseModel()
+        course.course_id = 'course-v1:etsx+Toeflss+2t2019'
+        other_course = BaseCourseModel()
+        for other in (
+                'course-v1:etsx+TOEFLSS+2t2019',
+                'course-v1:etsx+toeflss+2t2019',
+                'course-v1:etsx+toeflß+2t2019'
+        ):
+            other_course.course_id = other
+            self.assertNotEqual(course.course_id, other_course.course_id, other)
+            self.assertEqual(course.course_id_key(), other_course.course_id_key(), other)
+            

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -158,8 +158,8 @@ class CourseActivityWeeklyView(BaseCourseView):
         """
         formatted_data = []
 
-        data = sorted(data, key=lambda x: (x.course_id, x.interval_start, x.interval_end))
-        for key, group in groupby(data, lambda x: (x.course_id, x.interval_start, x.interval_end)):
+        data = sorted(data, key=lambda x: (x.course_id_key(), x.interval_start, x.interval_end))
+        for key, group in groupby(data, lambda x: (x.course_id_key(), x.interval_start, x.interval_end)):
             # Iterate over groups and create a single item with all activity types
             item = {
                 'course_id': key[0],


### PR DESCRIPTION
we've got trash case data in the user activity tables because of mixed case sensitivity across the pipeline

handle that in the API layer