### PR TITLE
build: update base ubuntu image from xenial to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as app
+FROM ubuntu:focal as app
 
 RUN apt update && \
   apt-get install -y software-properties-common && \


### PR DESCRIPTION
Starting on January 18, 2022, the Docker Push GitHub action started failing to build the Docker image. The logged error was "Unable to locate package python3.8-dev". I believe this is a result of the deadsnakes library no longer supporting ubuntu 16.04 (xenial). Please see the following issue in the deadsnakes repository: https://github.com/deadsnakes/issues/issues/195.

Upgrading the base ubuntu image to 20.04 (focal) is the recommended approach from the SRE team. Most of our Docker images are built upon this base ubuntu image already. The edxops/analytics_api:latest image also uses a ubuntu focal. Please see here: https://github.com/openedx/configuration/blob/master/docker/build/analytics_api/Dockerfile#L11.