### PR TITLE
fix: Pinned dnspython to stay below 2.7.0 as newer version require python upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -91,8 +91,10 @@ djangorestframework-csv==3.0.2
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-dnspython==2.7.0
-    # via pymongo
+dnspython==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,6 @@ urllib3<2.0.0
 
 # path>16.14.0 has removed the deprecated abspath function, which is breaking the docs build
 path<16.15.0
+
+# dnspython 2.7.0 Requires-Python >=3.9
+dnspython<2.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -91,8 +91,10 @@ djangorestframework-csv==3.0.2
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-dnspython==2.7.0
-    # via pymongo
+dnspython==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -101,8 +101,10 @@ djangorestframework-csv==3.0.2
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-dnspython==2.7.0
-    # via pymongo
+dnspython==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pymongo
 docutils==0.21.2
     # via
     #   pydata-sphinx-theme

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -91,8 +91,10 @@ djangorestframework-csv==3.0.2
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-dnspython==2.7.0
-    # via pymongo
+dnspython==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -106,8 +106,10 @@ djangorestframework-csv==3.0.2
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-dnspython==2.7.0
-    # via pymongo
+dnspython==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7


### PR DESCRIPTION
Pinned dnspython to stay below 2.7.0 as newer version require python upgrade