### PR TITLE
chore: bump edx-enterprise-data to 9.7.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,9 +11,9 @@ asgiref==3.8.1
     #   django-countries
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.35.58
+boto3==1.35.59
     # via -r requirements/base.in
-botocore==1.35.58
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer
@@ -37,7 +37,7 @@ cryptography==43.0.3
     #   pyjwt
 django==4.2.16
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
@@ -73,7 +73,7 @@ django-model-utils==5.0.0
     #   edx-rbac
 django-storages==1.10.1
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
 django-waffle==4.1.0
     # via
@@ -114,9 +114,9 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.7.1
+edx-enterprise-data==9.7.2
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
@@ -132,7 +132,7 @@ edx-rest-api-client==6.0.0
     #   edx-enterprise-data
 factory-boy==3.3.1
     # via edx-enterprise-data
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 html5lib==1.1
     # via -r requirements/base.in
@@ -238,7 +238,7 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.20
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   botocore
     #   requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,3 +30,7 @@ path<16.15.0
 # edx-enterprise-data==10.0.0 upgrades to Python 3.12 which is currently not supported
 # This constraint can be removed once Python 3.12 upgrade is complete
 edx-enterprise-data<10.0.0
+
+# Cause: https://github.com/openedx/edx-lint/issues/458
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
+pip<24.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,10 +10,10 @@ asgiref==3.8.1
     #   django-cors-headers
     #   django-countries
 boto==2.49.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-boto3==1.35.58
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-botocore==1.35.58
+    # via -r requirements/base.in
+boto3==1.35.59
+    # via -r requirements/base.in
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer
@@ -28,7 +28,7 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via edx-django-utils
 coreapi==2.3.3
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
 cryptography==43.0.3
@@ -37,8 +37,8 @@ cryptography==43.0.3
     #   pyjwt
 django==4.2.16
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields-v2
@@ -56,9 +56,9 @@ django==4.2.16
     #   edx-enterprise-data
     #   edx-rbac
 django-cors-headers==4.6.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-countries==7.6.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -73,15 +73,15 @@ django-model-utils==5.0.0
     #   edx-rbac
 django-storages==1.10.1
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
 djangorestframework==3.15.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   djangorestframework-csv
     #   drf-jwt
     #   drf-yasg
@@ -89,7 +89,7 @@ djangorestframework==3.15.2
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 dnspython==2.7.0
     # via pymongo
@@ -98,29 +98,29 @@ drf-jwt==1.19.2
 drf-yasg==1.21.8
     # via edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-ccx-keys==1.3.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-release-util==1.4.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-utils==7.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
 edx-drf-extensions==10.5.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.7.1
+edx-enterprise-data==9.7.2
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-enterprise-data
@@ -128,14 +128,14 @@ edx-rbac==1.10.0
     # via edx-enterprise-data
 edx-rest-api-client==6.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 factory-boy==3.3.1
     # via edx-enterprise-data
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 html5lib==1.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 idna==3.10
     # via requests
 inflection==0.5.1
@@ -149,12 +149,12 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 markdown==3.7
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 markupsafe==3.0.2
     # via jinja2
 mysql-connector-python==9.1.0
     # via edx-enterprise-data
-mysqlclient==2.2.5
+mysqlclient==2.2.6
     # via -r requirements/dev.in
 newrelic==10.2.0
     # via edx-django-utils
@@ -163,7 +163,7 @@ numpy==1.24.4
     #   edx-enterprise-data
     #   pandas
 ordered-set==4.1.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 packaging==24.2
     # via drf-yasg
 pandas==2.0.3
@@ -180,7 +180,7 @@ pyjwt[crypto]==2.9.0
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymemcache==4.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pymongo==4.10.1
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -191,7 +191,7 @@ python-dateutil==2.9.0.post0
     #   faker
     #   pandas
 python-memcached==1.62
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pytz==2024.2
     # via
     #   drf-yasg
@@ -226,7 +226,7 @@ stevedore==5.3.0
     #   edx-django-utils
     #   edx-opaque-keys
 tqdm==4.67.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 typing-extensions==4.12.2
     # via
     #   django-countries
@@ -240,8 +240,8 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.20
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   botocore
     #   requests
 webencodings==0.5.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,10 +20,10 @@ babel==2.16.0
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 boto==2.49.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-boto3==1.35.58
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-botocore==1.35.58
+    # via -r requirements/base.in
+boto3==1.35.59
+    # via -r requirements/base.in
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer
@@ -38,7 +38,7 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via edx-django-utils
 coreapi==2.3.3
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
 cryptography==43.0.3
@@ -47,8 +47,8 @@ cryptography==43.0.3
     #   pyjwt
 django==4.2.16
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields-v2
@@ -66,9 +66,9 @@ django==4.2.16
     #   edx-enterprise-data
     #   edx-rbac
 django-cors-headers==4.6.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-countries==7.6.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -83,15 +83,15 @@ django-model-utils==5.0.0
     #   edx-rbac
 django-storages==1.10.1
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
 djangorestframework==3.15.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   djangorestframework-csv
     #   drf-jwt
     #   drf-yasg
@@ -99,7 +99,7 @@ djangorestframework==3.15.2
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 dnspython==2.7.0
     # via pymongo
@@ -112,29 +112,29 @@ drf-jwt==1.19.2
 drf-yasg==1.21.8
     # via edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-ccx-keys==1.3.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-release-util==1.4.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-utils==7.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
 edx-drf-extensions==10.5.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.7.1
+edx-enterprise-data==9.7.2
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-enterprise-data
@@ -142,14 +142,14 @@ edx-rbac==1.10.0
     # via edx-enterprise-data
 edx-rest-api-client==6.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 factory-boy==3.3.1
     # via edx-enterprise-data
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 html5lib==1.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 idna==3.10
     # via requests
 imagesize==1.4.1
@@ -167,7 +167,7 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 markdown==3.7
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 markupsafe==3.0.2
     # via jinja2
 mysql-connector-python==9.1.0
@@ -179,7 +179,7 @@ numpy==1.24.4
     #   edx-enterprise-data
     #   pandas
 ordered-set==4.1.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 packaging==24.2
     # via
     #   drf-yasg
@@ -188,7 +188,7 @@ pandas==2.0.3
     # via edx-enterprise-data
 path==16.14.0
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
 pbr==6.1.0
     # via stevedore
@@ -209,7 +209,7 @@ pyjwt[crypto]==2.9.0
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymemcache==4.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pymongo==4.10.1
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -220,7 +220,7 @@ python-dateutil==2.9.0.post0
     #   faker
     #   pandas
 python-memcached==1.62
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pytz==2024.2
     # via
     #   drf-yasg
@@ -279,7 +279,7 @@ stevedore==5.3.0
     #   edx-django-utils
     #   edx-opaque-keys
 tqdm==4.67.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 typing-extensions==4.12.2
     # via
     #   django-countries
@@ -294,8 +294,8 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.20
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   botocore
     #   requests
 webencodings==0.5.1

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,9 @@ wheel==0.45.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.3.1
-    # via -r requirements/pip.in
+pip==24.2
+    # via
+    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
+    #   -r requirements/pip.in
 setuptools==75.4.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,10 +10,10 @@ asgiref==3.8.1
     #   django-cors-headers
     #   django-countries
 boto==2.49.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-boto3==1.35.58
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-botocore==1.35.58
+    # via -r requirements/base.in
+boto3==1.35.59
+    # via -r requirements/base.in
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer
@@ -28,7 +28,7 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via edx-django-utils
 coreapi==2.3.3
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
 cryptography==43.0.3
@@ -37,8 +37,8 @@ cryptography==43.0.3
     #   pyjwt
 django==4.2.16
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields-v2
@@ -56,9 +56,9 @@ django==4.2.16
     #   edx-enterprise-data
     #   edx-rbac
 django-cors-headers==4.6.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-countries==7.6.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -73,15 +73,15 @@ django-model-utils==5.0.0
     #   edx-rbac
 django-storages==1.10.1
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
 djangorestframework==3.15.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   djangorestframework-csv
     #   drf-jwt
     #   drf-yasg
@@ -89,7 +89,7 @@ djangorestframework==3.15.2
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 dnspython==2.7.0
     # via pymongo
@@ -98,29 +98,29 @@ drf-jwt==1.19.2
 drf-yasg==1.21.8
     # via edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-ccx-keys==1.3.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-release-util==1.4.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-utils==7.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
 edx-drf-extensions==10.5.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.7.1
+edx-enterprise-data==9.7.2
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-enterprise-data
@@ -128,11 +128,11 @@ edx-rbac==1.10.0
     # via edx-enterprise-data
 edx-rest-api-client==6.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 factory-boy==3.3.1
     # via edx-enterprise-data
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 gevent==24.11.1
     # via -r requirements/production.in
@@ -141,7 +141,7 @@ greenlet==3.1.1
 gunicorn==23.0.0
     # via -r requirements/production.in
 html5lib==1.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 idna==3.10
     # via requests
 inflection==0.5.1
@@ -155,12 +155,12 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 markdown==3.7
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 markupsafe==3.0.2
     # via jinja2
 mysql-connector-python==9.1.0
     # via edx-enterprise-data
-mysqlclient==2.2.5
+mysqlclient==2.2.6
     # via -r requirements/production.in
 newrelic==10.2.0
     # via
@@ -171,7 +171,7 @@ numpy==1.24.4
     #   edx-enterprise-data
     #   pandas
 ordered-set==4.1.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 packaging==24.2
     # via
     #   drf-yasg
@@ -192,7 +192,7 @@ pyjwt[crypto]==2.9.0
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymemcache==4.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pymongo==4.10.1
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -203,7 +203,7 @@ python-dateutil==2.9.0.post0
     #   faker
     #   pandas
 python-memcached==1.62
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pytz==2024.2
     # via
     #   drf-yasg
@@ -239,7 +239,7 @@ stevedore==5.3.0
     #   edx-django-utils
     #   edx-opaque-keys
 tqdm==4.67.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 typing-extensions==4.12.2
     # via
     #   django-countries
@@ -253,8 +253,8 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.20
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   botocore
     #   requests
 webencodings==0.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,10 +12,10 @@ asgiref==3.8.1
 astroid==3.3.5
     # via pylint
 boto==2.49.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-boto3==1.35.58
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
-botocore==1.35.58
+    # via -r requirements/base.in
+boto3==1.35.59
+    # via -r requirements/base.in
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer
@@ -32,7 +32,7 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via edx-django-utils
 coreapi==2.3.3
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
 coverage[toml]==7.6.4
@@ -50,8 +50,8 @@ diff-cover==9.2.0
 dill==0.3.9
     # via pylint
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields-v2
@@ -69,9 +69,9 @@ dill==0.3.9
     #   edx-enterprise-data
     #   edx-rbac
 django-cors-headers==4.6.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-countries==7.6.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -88,15 +88,15 @@ django-model-utils==5.0.0
     #   edx-rbac
 django-storages==1.10.1
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
 djangorestframework==3.15.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   djangorestframework-csv
     #   drf-jwt
     #   drf-yasg
@@ -104,7 +104,7 @@ djangorestframework==3.15.2
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 dnspython==2.7.0
     # via pymongo
@@ -113,29 +113,29 @@ drf-jwt==1.19.2
 drf-yasg==1.21.8
     # via edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-ccx-keys==1.3.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-release-util==1.4.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 edx-django-utils==7.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
 edx-drf-extensions==10.5.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.7.1
+edx-enterprise-data==9.7.2
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   edx-enterprise-data
@@ -143,16 +143,16 @@ edx-rbac==1.10.0
     # via edx-enterprise-data
 edx-rest-api-client==6.0.0
     # via
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -r requirements/base.in
     #   edx-enterprise-data
 factory-boy==3.3.1
     # via edx-enterprise-data
-faker==30.8.2
+faker==32.1.0
     # via factory-boy
 freezegun==1.5.1
     # via -r requirements/test.in
 html5lib==1.1
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 idna==3.10
     # via requests
 inflection==0.5.1
@@ -172,7 +172,7 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 markdown==3.7
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 markupsafe==3.0.2
     # via jinja2
 mccabe==0.7.0
@@ -186,7 +186,7 @@ numpy==1.24.4
     #   edx-enterprise-data
     #   pandas
 ordered-set==4.1.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 packaging==24.2
     # via
     #   drf-yasg
@@ -219,7 +219,7 @@ pyjwt[crypto]==2.9.0
 pylint==3.3.1
     # via -r requirements/test.in
 pymemcache==4.0.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pymongo==4.10.1
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -239,7 +239,7 @@ python-dateutil==2.9.0.post0
     #   freezegun
     #   pandas
 python-memcached==1.62
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 pytz==2024.2
     # via
     #   -r requirements/test.in
@@ -283,7 +283,7 @@ stevedore==5.3.0
 tomlkit==0.13.2
     # via pylint
 tqdm==4.67.0
-    # via -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    # via -r requirements/base.in
 typing-extensions==4.12.2
     # via
     #   django-countries
@@ -297,8 +297,8 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.20
     # via
-    #   -c /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/constraints.txt
-    #   -r /Users/usama.sadiq/Desktop/edX/edx-analytics-data-api/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   botocore
     #   requests
     #   responses


### PR DESCRIPTION
## Description
- Using `edx-enterprise-data==9.7.2` which backports changes from `10.2.0` and `10.3.0` for `Python 3.8` support.