### PR TITLE
fix: Pin django-cors-headers to version v4.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,7 @@ django==4.2.19
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==4.7.0
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-countries==7.6.1
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ django==4.2.19
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==4.7.0
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-countries==7.6.1
     # via -r requirements/base.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -65,7 +65,7 @@ django==4.2.19
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==4.7.0
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-countries==7.6.1
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -55,7 +55,7 @@ django==4.2.19
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==4.7.0
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-countries==7.6.1
     # via -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ dill==0.3.9
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==4.7.0
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-countries==7.6.1
     # via -r requirements/base.in


### PR DESCRIPTION
[GoCD Pipeline is failing](https://gocd.tools.edx.org/go/tab/build/detail/edx-analytics-api-stage/70/run_play/2/prod_edge) due to the following error:

> ERROR: Could not find a version that satisfies the requirement django-cors-headers==4.7.0 (from versions: 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.10, 0.11, 0.12, 0.13, 1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.3.0, 1.3.1, 2.0.0, 2.0.1, 2.0.2, 2.1.0, 2.2.0, 2.2.1, 2.3.0, 2.4.0, 2.4.1, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.2.0, 3.2.1, 3.3.0, 3.4.0, 3.5.0, 3.6.0, 3.7.0, 3.8.0, 3.9.0, 3.10.0, 3.10.1, 3.11.0, 3.12.0, 3.13.0, 3.14.0, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.3.1, 4.4.0)
> ERROR: No matching distribution found for django-cors-headers==4.7.0
> make: *** [Makefile:22: production-requirements] Error 1

According to [pypi, version 4.7.0 should be available](https://pypi.org/project/django-cors-headers/). In the meantime, in an attempt to fix the pipeline this PR pins the version to the latest available on the list `4.4.0`.