### PR TITLE
build: update requirements upgrade workflow to use python 3.11

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -15,7 +15,7 @@ jobs:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
-      python_version: "3.8"
+      python_version: "3.11"
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""


### PR DESCRIPTION
## Description
- Now that `Python 3.11` [upgrade](https://github.com/edx/edx-analytics-data-api/pull/96) has been completed, the requirements upgrade workflow needs to be updated or else it will downgrade dependencies with `Python 3.8` instead. See example [PR](https://github.com/edx/edx-analytics-data-api/pull/99/files#diff-0940fec0afe21798f617cc4522db676f15769ae28a72992b8d19216ef7b1c3b5R2) being closed.