### PR TITLE
chore: Removed edx-enterprise-data constraint as python version has been updated.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,9 +11,9 @@ asgiref==3.8.1
     #   django-countries
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.37.11
+boto3==1.37.13
     # via -r requirements/base.in
-botocore==1.37.11
+botocore==1.37.13
     # via
     #   boto3
     #   s3transfer
@@ -116,10 +116,8 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.9.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-enterprise-data==10.10.0
+    # via -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
     #   -r requirements/base.in
@@ -158,7 +156,7 @@ mysql-connector-python==9.2.0
     # via edx-enterprise-data
 newrelic==10.7.0
     # via edx-django-utils
-numpy==1.24.4
+numpy==2.2.4
     # via
     #   edx-enterprise-data
     #   pandas
@@ -166,7 +164,7 @@ ordered-set==4.1.0
     # via -r requirements/base.in
 packaging==24.2
     # via drf-yasg
-pandas==2.0.3
+pandas==2.2.3
     # via edx-enterprise-data
 pbr==6.1.1
     # via stevedore

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,10 +30,6 @@ path<16.15.0
 # dnspython 2.7.0 Requires-Python >=3.9
 dnspython<2.7.0
 
-# edx-enterprise-data==10.0.0 upgrades to Python 3.12 which is currently not supported
-# This constraint can be removed once Python 3.12 upgrade is complete
-edx-enterprise-data<10.0.0
-
 # backports-zoneinfo comes by-default in newer versions of python
 # it gives error while building wheel with python>=3.9
 backports.zoneinfo ; python_version < "3.9"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,9 +11,9 @@ asgiref==3.8.1
     #   django-countries
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.37.11
+boto3==1.37.13
     # via -r requirements/base.in
-botocore==1.37.11
+botocore==1.37.13
     # via
     #   boto3
     #   s3transfer
@@ -116,10 +116,8 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.9.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-enterprise-data==10.10.0
+    # via -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
     #   -r requirements/base.in
@@ -160,7 +158,7 @@ mysqlclient==2.2.7
     # via -r requirements/dev.in
 newrelic==10.7.0
     # via edx-django-utils
-numpy==1.24.4
+numpy==2.2.4
     # via
     #   edx-enterprise-data
     #   pandas
@@ -168,7 +166,7 @@ ordered-set==4.1.0
     # via -r requirements/base.in
 packaging==24.2
     # via drf-yasg
-pandas==2.0.3
+pandas==2.2.3
     # via edx-enterprise-data
 pbr==6.1.1
     # via stevedore

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -21,9 +21,9 @@ beautifulsoup4==4.13.3
     # via pydata-sphinx-theme
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.37.11
+boto3==1.37.13
     # via -r requirements/base.in
-botocore==1.37.11
+botocore==1.37.13
     # via
     #   boto3
     #   s3transfer
@@ -130,10 +130,8 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.9.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-enterprise-data==10.10.0
+    # via -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
     #   -r requirements/base.in
@@ -176,7 +174,7 @@ mysql-connector-python==9.2.0
     # via edx-enterprise-data
 newrelic==10.7.0
     # via edx-django-utils
-numpy==1.24.4
+numpy==2.2.4
     # via
     #   edx-enterprise-data
     #   pandas
@@ -187,7 +185,7 @@ packaging==24.2
     #   drf-yasg
     #   pydata-sphinx-theme
     #   sphinx
-pandas==2.0.3
+pandas==2.2.3
     # via edx-enterprise-data
 path==16.14.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,9 +11,9 @@ asgiref==3.8.1
     #   django-countries
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.37.11
+boto3==1.37.13
     # via -r requirements/base.in
-botocore==1.37.11
+botocore==1.37.13
     # via
     #   boto3
     #   s3transfer
@@ -116,10 +116,8 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.9.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-enterprise-data==10.10.0
+    # via -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
     #   -r requirements/base.in
@@ -168,7 +166,7 @@ newrelic==10.7.0
     # via
     #   -r requirements/production.in
     #   edx-django-utils
-numpy==1.24.4
+numpy==2.2.4
     # via
     #   edx-enterprise-data
     #   pandas
@@ -178,7 +176,7 @@ packaging==24.2
     # via
     #   drf-yasg
     #   gunicorn
-pandas==2.0.3
+pandas==2.2.3
     # via edx-enterprise-data
 path-py==8.2.1
     # via -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,9 +13,9 @@ astroid==3.3.9
     # via pylint
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.37.11
+boto3==1.37.13
     # via -r requirements/base.in
-botocore==1.37.11
+botocore==1.37.13
     # via
     #   boto3
     #   s3transfer
@@ -35,7 +35,7 @@ coreapi==2.3.3
     # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
-coverage[toml]==7.6.12
+coverage[toml]==7.7.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -131,10 +131,8 @@ edx-drf-extensions==10.5.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==9.9.2
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-enterprise-data==10.10.0
+    # via -r requirements/base.in
 edx-opaque-keys==2.11.0
     # via
     #   -r requirements/base.in
@@ -183,7 +181,7 @@ mysql-connector-python==9.2.0
     # via edx-enterprise-data
 newrelic==10.7.0
     # via edx-django-utils
-numpy==1.24.4
+numpy==2.2.4
     # via
     #   edx-enterprise-data
     #   pandas
@@ -193,7 +191,7 @@ packaging==24.2
     # via
     #   drf-yasg
     #   pytest
-pandas==2.0.3
+pandas==2.2.3
     # via edx-enterprise-data
 pbr==6.1.1
     # via stevedore

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv


### PR DESCRIPTION
This PR removes `edx-enterprise-data<10.0.0` constraint because it is no longer needed. The python version upgrade is complete.