### PR TITLE
chore: bump edx-enterprise-data from 10.22.2 to 10.22.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -116,7 +116,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.2
+edx-enterprise-data==10.22.4
     # via -r requirements/base.in
 edx-opaque-keys==3.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -116,7 +116,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.2
+edx-enterprise-data==10.22.4
     # via -r requirements/base.in
 edx-opaque-keys==3.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -130,7 +130,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.2
+edx-enterprise-data==10.22.4
     # via -r requirements/base.in
 edx-opaque-keys==3.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -116,7 +116,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.2
+edx-enterprise-data==10.22.4
     # via -r requirements/base.in
 edx-opaque-keys==3.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -131,7 +131,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.2
+edx-enterprise-data==10.22.4
     # via -r requirements/base.in
 edx-opaque-keys==3.0.0
     # via


### PR DESCRIPTION
## [ENT-11183] Bump `edx-enterprise-data` from `10.22.2` to `10.22.4`

### What changed and why?

Upgrades the `edx-enterprise-data` dependency to [`10.22.4`](https://github.com/openedx/edx-enterprise-data/releases/tag/10.22.4) to pick up the latest bug fixes, improvements, and security patches included in the upstream release.

This is a targeted version pin bump — no application code was modified.

### Files changed

| File | Change |
|------|--------|
| `requirements/base.txt` | `10.22.2` → `10.22.4` |
| `requirements/dev.txt` | `10.22.2` → `10.22.4` |
| `requirements/doc.txt` | `10.22.2` → `10.22.4` |
| `requirements/production.txt` | `10.22.2` → `10.22.4` |
| `requirements/test.txt` | `10.22.2` → `10.22.4` |

### Testing

- [ ] CI passes with the new dependency version
- [ ] No breaking changes identified in the [10.22.4 release notes](https://github.com/openedx/edx-enterprise-data/releases/tag/10.22.4)

### Notes

- This PR contains **only** the dependency bump. Unrelated local changes are excluded.
- The source of truth for this package is `requirements/base.in` (unpinned); the `.txt` files are the compiled lockfiles updated here.
