### PR TITLE
chore: bump edx-enterprise-data from 10.22.4 to 10.22.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.4
+edx-enterprise-data==10.22.5
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -112,7 +112,8 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.4
+
+edx-enterprise-data==10.22.5
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -126,7 +126,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.4
+edx-enterprise-data==10.22.5
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.4
+edx-enterprise-data==10.22.5
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -127,7 +127,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.4
+edx-enterprise-data==10.22.5
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
## Summary
- Bump edx-enterprise-data from 10.22.4 to 10.22.5.


## Testing
- Not run locally (requirements-only change).

