### PR TITLE
chore: version bump of enterprise-data from 10.22.5 to 10.22.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.5
+edx-enterprise-data==10.22.7
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ edx-drf-extensions==10.6.0
     #   edx-enterprise-data
     #   edx-rbac
 
-edx-enterprise-data==10.22.5
+edx-enterprise-data==10.22.7
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -126,7 +126,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.5
+edx-enterprise-data==10.22.7
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.5
+edx-enterprise-data==10.22.7
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -127,7 +127,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.5
+edx-enterprise-data==10.22.7
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
Summary
This PR updates the enterprise-data dependency from v10.22.5 to v10.22.7.
Details
As part of this upgrade, changes have been introduced to support Snowflake authentication migration:

Transitioned from username/password-based authentication
To private key and passphrase-based authentication

These updates improve security and align with the recommended authentication mechanism for Snowflake integrations.