### PR TITLE
chore: bump edx-enterprise-data to 10.22.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.7
+edx-enterprise-data==10.22.8
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ edx-drf-extensions==10.6.0
     #   edx-enterprise-data
     #   edx-rbac
 
-edx-enterprise-data==10.22.7
+edx-enterprise-data==10.22.8
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -126,7 +126,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.7
+edx-enterprise-data==10.22.8
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.7
+edx-enterprise-data==10.22.8
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -127,7 +127,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.7
+edx-enterprise-data==10.22.8
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
## Description

ENT-11807 — Bumps `edx-enterprise-data` from 10.22.7 → **10.22.8** so the analytics API serves:

- the segmented engagement fields (`is_engaged_video`, `is_engaged_forum`, `is_engaged_problem`) in the individual engagements API response and CSV download (openedx/edx-enterprise-data#686), and
- the Snowflake private-key escaped-newline fix for the LPR data source.

