### PR TITLE
chore: bump edx-enterprise-data from 10.22.8 to 10.22.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.8
+edx-enterprise-data==10.22.9
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ edx-drf-extensions==10.6.0
     #   edx-enterprise-data
     #   edx-rbac
 
-edx-enterprise-data==10.22.8
+edx-enterprise-data==10.22.9
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -126,7 +126,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.8
+edx-enterprise-data==10.22.9
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.8
+edx-enterprise-data==10.22.9
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -127,7 +127,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.8
+edx-enterprise-data==10.22.9
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
### Description

ENT-11979 — Bumps edx-enterprise-data from 10.22.8 → 10.22.9 so the analytics API includes:

- The latest fixes and enhancements delivered in the 10.22.9 release.(https://github.com/openedx/edx-enterprise-data/pull/690)
- The updated edx-enterprise-data dependency (10.22.9) required by the analytics API.
