### PR TITLE
chore: bump edx-enterprise-data to 10.22.10 in requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.9
+edx-enterprise-data==10.22.10
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,7 +113,7 @@ edx-drf-extensions==10.6.0
     #   edx-enterprise-data
     #   edx-rbac
 
-edx-enterprise-data==10.22.9
+edx-enterprise-data==10.22.10
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -126,7 +126,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.9
+edx-enterprise-data==10.22.10
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -112,7 +112,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.9
+edx-enterprise-data==10.22.10
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -127,7 +127,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.9
+edx-enterprise-data==10.22.10
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
Summary:
JIRA ticket: https://2u-internal.atlassian.net/browse/ENT-10867

Version updating of edx-enterprise-data to 10.22.10