### PR TITLE
chore: bump edx-enterprise-data from 10.22.10 to 10.22.12

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -124,7 +124,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.10
+edx-enterprise-data==10.22.12
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -124,7 +124,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.10
+edx-enterprise-data==10.22.12
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -138,7 +138,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.10
+edx-enterprise-data==10.22.12
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -124,7 +124,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.10
+edx-enterprise-data==10.22.12
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -140,7 +140,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==10.22.10
+edx-enterprise-data==10.22.12
     # via -r requirements/base.in
 edx-opaque-keys==4.0.0
     # via


### PR DESCRIPTION
### Description

ENT-11979 — Bumps edx-enterprise-data from 10.22.10 → 10.22.12 so the analytics API includes:

The latest fixes and enhancements delivered in the 10.22.12 release.
The updated edx-enterprise-data dependency (10.22.12) required by the analytics API.